### PR TITLE
Facility details mobile

### DIFF
--- a/app/assets/javascripts/AppFacilityDetails.elm
+++ b/app/assets/javascripts/AppFacilityDetails.elm
@@ -94,7 +94,7 @@ view model =
         hideOnMobileDetailsFocused =
             ( "hide-on-med-and-down", not (mobileFocusMap model) )
     in
-        { headerAttributes = classList [ hideOnMobileDetailsFocused ]
+        { headerAttributes = [ classList [ hideOnMobileDetailsFocused ] ]
         , content =
             [ case model of
                 Loading _ _ _ _ ->

--- a/app/assets/javascripts/AppFacilityDetails.elm
+++ b/app/assets/javascripts/AppFacilityDetails.elm
@@ -5,7 +5,7 @@ import Html exposing (..)
 import Html.App
 import Html.Attributes exposing (..)
 import Html.Events as Events
-import Shared
+import Shared exposing (MapView)
 import Api
 import Date exposing (Date)
 import Utils exposing (mapTCmd)
@@ -18,13 +18,14 @@ import UserLocation
 
 type Model
     = Loading MapViewport Int (Maybe Date) UserLocation.Model
-    | Loaded MapViewport Facility (Maybe Date) UserLocation.Model
+    | Loaded MapViewport Facility (Maybe Date) UserLocation.Model Bool
 
 
 type PrivateMsg
     = ApiFetch Api.FetchFacilityMsg
     | CurrentDate Date
     | UserLocationMsg UserLocation.Msg
+    | ToggleMobileFocus
 
 
 type Msg
@@ -51,7 +52,7 @@ update s msg model =
                     ( setDate date model, Cmd.none )
 
                 ApiFetch (Api.FetchFacilitySuccess facility) ->
-                    (Loaded (mapViewport model) facility (date model) (userLocation model))
+                    (Loaded (mapViewport model) facility (date model) (userLocation model) False)
                         ! ((if (Models.contains (mapViewport model) facility.position) then
                                 []
                             else
@@ -64,6 +65,14 @@ update s msg model =
                     mapTCmd (\l -> setUserLocation l model) (Private << UserLocationMsg) <|
                         UserLocation.update s msg (userLocation model)
 
+                ToggleMobileFocus ->
+                    case model of
+                        Loading _ _ _ _ ->
+                            ( model, Cmd.none )
+
+                        Loaded a b c d e ->
+                            ( Loaded a b c d (not e), Cmd.none )
+
                 _ ->
                     -- TODO handle error
                     ( model, Cmd.none )
@@ -73,12 +82,21 @@ update s msg model =
             ( model, Cmd.none )
 
 
-view : Model -> Html Msg
+view : Model -> MapView Msg
 view model =
-    div []
-        [ Shared.controlStack
-            [ div [ class "hide-on-med-and-down" ] [ Shared.header ]
-            , case model of
+    let
+        onlyMobile =
+            ( "hide-on-large-only", True )
+
+        hideOnMobileMapFocused =
+            ( "hide-on-med-and-down", mobileFocusMap model )
+
+        hideOnMobileDetailsFocused =
+            ( "hide-on-med-and-down", not (mobileFocusMap model) )
+    in
+        { headerAttributes = classList [ hideOnMobileDetailsFocused ]
+        , content =
+            [ case model of
                 Loading _ _ _ _ ->
                     div
                         [ class "preloader-wrapper small active" ]
@@ -92,11 +110,25 @@ view model =
                             ]
                         ]
 
-                Loaded _ facility date _ ->
-                    facilityDetail date facility
+                Loaded _ facility date _ mobileFocusMap ->
+                    facilityDetail [ hideOnMobileMapFocused ] date facility
             ]
-        , userLocationView model
+        , toolbar =
+            [ userLocationView model ]
+        , bottom =
+            [ div
+                [ classList [ hideOnMobileDetailsFocused ] ]
+                [ mobileFocusToggleView ]
+            ]
+        }
+
+
+mobileFocusToggleView =
+    a
+        [ href "#"
+        , Shared.onClick (Private ToggleMobileFocus)
         ]
+        [ text "Show details" ]
 
 
 userLocationView model =
@@ -114,7 +146,7 @@ mapViewport model =
         Loading mapViewport _ _ _ ->
             mapViewport
 
-        Loaded mapViewport _ _ _ ->
+        Loaded mapViewport _ _ _ _ ->
             mapViewport
 
 
@@ -124,7 +156,7 @@ date model =
         Loading _ _ date _ ->
             date
 
-        Loaded _ _ date _ ->
+        Loaded _ _ date _ _ ->
             date
 
 
@@ -134,8 +166,8 @@ setDate date model =
         Loading a b _ d ->
             Loading a b (Just date) d
 
-        Loaded a b _ d ->
-            Loaded a b (Just date) d
+        Loaded a b _ d e ->
+            Loaded a b (Just date) d e
 
 
 userLocation : Model -> UserLocation.Model
@@ -144,7 +176,7 @@ userLocation model =
         Loading _ _ _ userLocation ->
             userLocation
 
-        Loaded _ _ _ userLocation ->
+        Loaded _ _ _ userLocation _ ->
             userLocation
 
 
@@ -154,8 +186,18 @@ setUserLocation userLocation model =
         Loading a b c _ ->
             Loading a b c userLocation
 
-        Loaded a b c _ ->
-            Loaded a b c userLocation
+        Loaded a b c _ e ->
+            Loaded a b c userLocation e
+
+
+mobileFocusMap : Model -> Bool
+mobileFocusMap model =
+    case model of
+        Loading _ _ _ _ ->
+            True
+
+        Loaded _ _ _ _ b ->
+            b
 
 
 currentDate : Cmd Msg
@@ -167,8 +209,8 @@ currentDate =
         Task.perform notFailing (Utils.dateFromEpochMillis >> CurrentDate >> Private) Time.now
 
 
-facilityDetail : Maybe Date -> Facility -> Html Msg
-facilityDetail now facility =
+facilityDetail : List ( String, Bool ) -> Maybe Date -> Facility -> Html Msg
+facilityDetail cssClasses now facility =
     let
         lastUpdatedSub =
             case facility.lastUpdated of
@@ -190,7 +232,7 @@ facilityDetail now facility =
               -- , entry "directions" facility.address
             ]
     in
-        div [ class "facilityDetail" ]
+        div [ classList <| ( "facilityDetail", True ) :: cssClasses ]
             [ div [ class "title" ]
                 [ span [ class "name" ]
                     [ text facility.name
@@ -214,12 +256,21 @@ facilityDetail now facility =
             ]
 
 
-facilityContactDetails : List ( String, String ) -> Html msg
+facilityContactDetails : List ( String, String ) -> Html Msg
 facilityContactDetails attributes =
     let
         item ( iconName, information ) =
             li [] [ Shared.icon iconName, span [] [ text information ] ]
     in
-        attributes
-            |> List.map item
-            |> ul []
+        ul [] <|
+            (List.map item attributes
+                ++ [ li [ class "hide-on-large-only" ]
+                        [ Shared.icon "location_on"
+                        , a
+                            [ href "#"
+                            , Shared.onClick (Private ToggleMobileFocus)
+                            ]
+                            [ text "View on map" ]
+                        ]
+                   ]
+            )

--- a/app/assets/javascripts/AppHome.elm
+++ b/app/assets/javascripts/AppHome.elm
@@ -5,7 +5,7 @@ import Html exposing (..)
 import Html.App
 import Map
 import Models exposing (Settings, MapViewport, LatLng, SearchResult, shouldLoadMore)
-import Shared
+import Shared exposing (MapView)
 import Utils exposing (mapFst, mapTCmd)
 import UserLocation
 import Suggest
@@ -101,13 +101,13 @@ wrapSuggest model =
     mapTCmd (\s -> { model | suggest = s }) (Private << SuggestMsg)
 
 
-view : Model -> Html Msg
+view : Model -> MapView Msg
 view model =
-    div []
-        [ Shared.headerWithContent
-            (suggestionInput model :: (suggestionItems model))
-        , userLocationView model
-        ]
+    { headerAttributes = []
+    , content = suggestionInput model :: (suggestionItems model)
+    , toolbar = [ userLocationView model ]
+    , bottom = []
+    }
 
 
 suggestionInput model =

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -7,7 +7,7 @@ import Html.App
 import Html.Attributes exposing (..)
 import Html.Events as Events
 import Models exposing (Settings, MapViewport, SearchSpec, SearchResult, Facility, LatLng, shouldLoadMore)
-import Shared exposing (icon)
+import Shared exposing (MapView, icon)
 import Utils exposing (mapTCmd)
 import UserLocation
 import Suggest
@@ -137,7 +137,7 @@ wrapSuggest model =
     mapTCmd (\s -> { model | suggest = s }) (Private << SuggestMsg)
 
 
-view : Model -> Html Msg
+view : Model -> MapView Msg
 view model =
     let
         onlyMobile =
@@ -152,24 +152,25 @@ view model =
         hideOnSuggestions =
             ( "hide", Suggest.hasSuggestionsToShow model.suggest )
     in
-        div []
-            [ Shared.controlStack
-                ([ div [ classList [ hideOnMobileListingFocused ] ] [ Shared.header ]
-                 , div
-                    [ classList [ onlyMobile, hideOnMobileMapFocused ] ]
-                    [ mobileBackHeader ]
-                 , suggestionInput model
-                 , div
-                    [ classList [ hideOnSuggestions, hideOnMobileMapFocused ] ]
-                    [ searchResults model ]
-                 ]
-                    ++ suggestionItems model
-                )
+        { headerAttributes = classList [ hideOnMobileListingFocused ]
+        , content =
+            [ div
+                [ classList [ onlyMobile, hideOnMobileMapFocused ] ]
+                [ mobileBackHeader ]
+            , suggestionInput model
             , div
-                [ classList [ hideOnMobileListingFocused, onlyMobile ] ]
-                [ mobileFocusToggleView ]
-            , userLocationView model
+                [ classList [ hideOnSuggestions, hideOnMobileMapFocused ] ]
+                [ searchResults model ]
             ]
+                ++ suggestionItems model
+        , toolbar =
+            [ userLocationView model ]
+        , bottom =
+            [ div
+                [ classList [ hideOnMobileListingFocused ] ]
+                [ mobileFocusToggleView ]
+            ]
+        }
 
 
 mobileBackHeader =
@@ -198,16 +199,12 @@ suggestionItems model =
 
 
 userLocationView model =
-    div [ class "floating-actions" ]
-        [ Html.App.map (Private << UserLocationMsg) (UserLocation.viewMapControl model.userLocation)
-        ]
+    Html.App.map (Private << UserLocationMsg) (UserLocation.viewMapControl model.userLocation)
 
 
 mobileFocusToggleView =
     a
         [ href "#!"
-        , id "bottom-action"
-        , class "z-depth-1"
         , Shared.onClick (Private ToggleMobileFocus)
         ]
         [ text "List results" ]

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -204,7 +204,7 @@ userLocationView model =
 
 mobileFocusToggleView =
     a
-        [ href "#!"
+        [ href "#"
         , Shared.onClick (Private ToggleMobileFocus)
         ]
         [ text "List results" ]

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -152,7 +152,7 @@ view model =
         hideOnSuggestions =
             ( "hide", Suggest.hasSuggestionsToShow model.suggest )
     in
-        { headerAttributes = classList [ hideOnMobileListingFocused ]
+        { headerAttributes = [ classList [ hideOnMobileListingFocused ] ]
         , content =
             [ div
                 [ classList [ onlyMobile, hideOnMobileMapFocused ] ]

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -325,10 +325,10 @@ mainView mainModel =
             mapView SearchMsg <| AppSearch.view model
 
         InitializingVR _ _ _ ->
-            Shared.mapWithControl Nothing
+            mapView identity { headerAttributes = [], content = [], toolbar = [], bottom = [] }
 
         InitializedVR _ _ ->
-            Shared.mapWithControl Nothing
+            mapView identity { headerAttributes = [], content = [], toolbar = [], bottom = [] }
 
 
 mapView : (a -> MainMsg) -> Shared.MapView a -> Html MainMsg

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -316,7 +316,7 @@ mainView : MainModel -> Html MainMsg
 mainView mainModel =
     case mainModel of
         HomeModel model settings ->
-            Shared.layout <| Html.App.map HomeMsg <| AppHome.view model
+            mapView HomeMsg <| AppHome.view model
 
         FacilityDetailsModel model settings _ ->
             mapView FacilityDetailsMsg <| AppFacilityDetails.view model
@@ -338,11 +338,14 @@ mapView wmsg viewContent =
             (div
                 []
                 ([ Shared.controlStack
-                    ((div [ viewContent.headerAttributes ] [ Shared.header ]) :: viewContent.content)
+                    ((div viewContent.headerAttributes [ Shared.header ]) :: viewContent.content)
                  ]
-                    ++ [ div [ id "bottom-action", class "z-depth-1" ] viewContent.bottom
-                       , div [ class "floating-actions" ] viewContent.toolbar
-                       ]
+                    ++ (if List.isEmpty viewContent.bottom then
+                            []
+                        else
+                            [ div [ id "bottom-action", class "z-depth-1" ] viewContent.bottom ]
+                       )
+                    ++ [ div [ class "map-toolbar" ] viewContent.toolbar ]
                 )
             )
 

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -9,7 +9,8 @@ import AppHome
 import AppSearch
 import AppFacilityDetails
 import UserLocation
-import Html exposing (Html)
+import Html exposing (Html, div)
+import Html.Attributes exposing (id, class)
 import Html.App
 import Utils exposing (mapFst, mapSnd, mapTCmd)
 
@@ -321,13 +322,29 @@ mainView mainModel =
             Shared.layout <| Html.App.map FacilityDetailsMsg <| AppFacilityDetails.view model
 
         SearchModel model settings ->
-            Shared.layout <| Html.App.map SearchMsg <| AppSearch.view model
+            mapView SearchMsg <| AppSearch.view model
 
         InitializingVR _ _ _ ->
             Shared.mapWithControl Nothing
 
         InitializedVR _ _ ->
             Shared.mapWithControl Nothing
+
+
+mapView : (a -> MainMsg) -> Shared.MapView a -> Html MainMsg
+mapView wmsg viewContent =
+    Shared.layout <|
+        Html.App.map wmsg
+            (div
+                []
+                ([ Shared.controlStack
+                    ((div [ viewContent.headerAttributes ] [ Shared.header ]) :: viewContent.content)
+                 ]
+                    ++ [ div [ id "bottom-action", class "z-depth-1" ] viewContent.bottom
+                       , div [ class "floating-actions" ] viewContent.toolbar
+                       ]
+                )
+            )
 
 
 navigateHome : Cmd MainMsg

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -319,7 +319,7 @@ mainView mainModel =
             Shared.layout <| Html.App.map HomeMsg <| AppHome.view model
 
         FacilityDetailsModel model settings _ ->
-            Shared.layout <| Html.App.map FacilityDetailsMsg <| AppFacilityDetails.view model
+            mapView FacilityDetailsMsg <| AppFacilityDetails.view model
 
         SearchModel model settings ->
             mapView SearchMsg <| AppSearch.view model

--- a/app/assets/javascripts/Shared.elm
+++ b/app/assets/javascripts/Shared.elm
@@ -8,6 +8,18 @@ import Models
 import String
 
 
+type alias LHtml a =
+    List (Html a)
+
+
+type alias MapView a =
+    { headerAttributes : Attribute a
+    , content : LHtml a
+    , toolbar : LHtml a
+    , bottom : LHtml a
+    }
+
+
 mapWithControl : Maybe (Html a) -> Html a
 mapWithControl content =
     layout (mapControl content)

--- a/app/assets/javascripts/Shared.elm
+++ b/app/assets/javascripts/Shared.elm
@@ -20,11 +20,6 @@ type alias MapView a =
     }
 
 
-mapWithControl : Maybe (Html a) -> Html a
-mapWithControl content =
-    layout (mapControl content)
-
-
 mapCanvas : Html a
 mapCanvas =
     div [ id "map" ] []
@@ -35,26 +30,9 @@ layout content =
     div [ id "container" ] [ mapCanvas, content ]
 
 
-headerWithContent : List (Html a) -> Html a
-headerWithContent content =
-    div [ id "map-control", class "z-depth-1" ] (header :: content)
-
-
 controlStack : List (Html a) -> Html a
 controlStack content =
     div [ id "map-control", class "z-depth-1" ] content
-
-
-mapControl : Maybe (Html a) -> Html a
-mapControl content =
-    headerWithContent
-        (case content of
-            Nothing ->
-                []
-
-            Just content ->
-                [ content ]
-        )
 
 
 header : Html a

--- a/app/assets/javascripts/Shared.elm
+++ b/app/assets/javascripts/Shared.elm
@@ -13,7 +13,7 @@ type alias LHtml a =
 
 
 type alias MapView a =
-    { headerAttributes : Attribute a
+    { headerAttributes : List (Attribute a)
     , content : LHtml a
     , toolbar : LHtml a
     , bottom : LHtml a

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -258,6 +258,13 @@ html, body, #container, #elm, #map {
     border-top: 1px solid $grey3;
   }
 
+  a {
+    color: $blue;
+    &:hover {
+      color: $light-blue;
+    }
+  }
+
   .title {
     display: flex;
     align-items: center;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -384,7 +384,7 @@ html, body, #container, #elm, #map {
     }
   }
 
-  .floating-actions {
+  #bottom-action + .map-toolbar {
     position: relative;
     bottom: 45px;
   }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -355,17 +355,26 @@ html, body, #container, #elm, #map {
     align-items: center;
     background-color: #ffffff;
     bottom: 0;
-    color: #777777;
     display: flex;
     font-size: 13pt;
     height: 55px;
     padding: 15px;
     position: absolute;
     text-transform: uppercase;
-    width: 100%;
     justify-content: center;
     font-weight: 500;
     z-index: 1;
+    width: 100%;
+    flex: 1;
+    div {
+      width: 100%;
+    }
+    a {
+      text-align: center;
+      display: inline-block;
+      color: #777777;
+      width: 100%;
+    }
   }
 
   .floating-actions {


### PR DESCRIPTION
fixes #43 
a view refactor to implement #42 in the future.

Facility details works as follows:
* desktop
<img width="1052" alt="facility-details-desktop" src="https://cloud.githubusercontent.com/assets/459923/19482178/a51f34cc-9526-11e6-98b5-c0bda3f0953d.png">

* mobile card (default)
it has a "View on map" option that is only visible in mobile devices.
<img width="402" alt="facility-details-card-mobile" src="https://cloud.githubusercontent.com/assets/459923/19482184/aabc974e-9526-11e6-8711-f7a399fa8863.png">


* mobile map
<img width="402" alt="facility-details-map-mobile" src="https://cloud.githubusercontent.com/assets/459923/19482186/b0b63c4a-9526-11e6-8733-14f6ce99d840.png">

