### PR TITLE
I18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
-public/javascripts/i18n.js
-public/javascripts/translations.js
+app/assets/javascripts/i18n/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+public/javascripts/i18n.js
+public/javascripts/translations.js

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'jbuilder', '~> 2.5'
 
 gem 'elasticsearch'
 gem 'config'
+gem 'i18n-js', '>= 3.0.0.rc14'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-materialize'

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'elasticsearch'
 gem 'config'
 gem 'i18n-js', '>= 3.0.0.rc14'
+gem 'http_accept_language'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-materialize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     ffi (1.9.14)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    http_accept_language (2.0.5)
     i18n (0.7.0)
     i18n-js (3.0.0.rc14)
       i18n (~> 0.6, >= 0.6.6)
@@ -199,6 +200,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   config
   elasticsearch
+  http_accept_language
   i18n-js (>= 3.0.0.rc14)
   jbuilder (~> 2.5)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    i18n-js (3.0.0.rc14)
+      i18n (~> 0.6, >= 0.6.6)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -197,6 +199,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   config
   elasticsearch
+  i18n-js (>= 3.0.0.rc14)
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
@@ -215,4 +218,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.13.2
+   1.13.5

--- a/app/assets/javascripts/AppFacilityDetails.elm
+++ b/app/assets/javascripts/AppFacilityDetails.elm
@@ -17,6 +17,7 @@ import UserLocation
 import Http
 import Json.Decode as Decode
 import Json.Encode exposing (..)
+import I18n exposing (..)
 
 
 type Model
@@ -169,7 +170,7 @@ reportWindow model =
     if isReportWindowOpen model then
         [ div [ class "modal-content" ]
             [ div [ class "header" ]
-                [ text "Report an issue"
+                [ text <| t ReportAnIssue
                 , a [ href "#", class "right", Shared.onClick (Private ToggleFacilityReport) ] [ Shared.icon "close" ]
                 ]
             , div [ class "body" ]
@@ -470,5 +471,5 @@ facilityActions =
     a
         [ href "#", Shared.onClick (Private ToggleFacilityReport) ]
         [ Shared.icon "report"
-        , text "Report an issue"
+        , text <| t ReportAnIssue
         ]

--- a/app/assets/javascripts/AppFacilityDetails.elm
+++ b/app/assets/javascripts/AppFacilityDetails.elm
@@ -417,7 +417,7 @@ facilityDetail cssClasses now facility =
                 , div [ class "detailSection actions" ] [ facilityActions ]
                 , div [ class "detailSection contact" ] [ facilityContactDetails contactInfo ]
                 , div [ class "detailSection services" ]
-                    [ span [] [ text "Services" ]
+                    [ span [] [ text <| t Services ]
                     , if List.isEmpty facility.services then
                         div [ class "noData" ] [ text "There is currently no information about services provided by this facility." ]
                       else

--- a/app/assets/javascripts/I18n.elm
+++ b/app/assets/javascripts/I18n.elm
@@ -8,6 +8,7 @@ type TranslationId
     | Map
     | ApiDocs
     | Contact
+    | FacilitiesCount { count : Int }
 
 
 t : TranslationId -> String

--- a/app/assets/javascripts/I18n.elm
+++ b/app/assets/javascripts/I18n.elm
@@ -7,6 +7,7 @@ type TranslationId
     = SearchHealthFacility
     | Map
     | ApiDocs
+    | Services
     | Contact
     | FacilitiesCount { count : Int }
     | ReportAnIssue

--- a/app/assets/javascripts/I18n.elm
+++ b/app/assets/javascripts/I18n.elm
@@ -9,6 +9,7 @@ type TranslationId
     | ApiDocs
     | Contact
     | FacilitiesCount { count : Int }
+    | ReportAnIssue
 
 
 t : TranslationId -> String

--- a/app/assets/javascripts/I18n.elm
+++ b/app/assets/javascripts/I18n.elm
@@ -5,6 +5,9 @@ import Native.I18n
 
 type TranslationId
     = SearchHealthFacility
+    | Map
+    | ApiDocs
+    | Contact
 
 
 t : TranslationId -> String

--- a/app/assets/javascripts/I18n.elm
+++ b/app/assets/javascripts/I18n.elm
@@ -1,0 +1,12 @@
+module I18n exposing (..)
+
+import Native.I18n
+
+
+type TranslationId
+    = SearchHealthFacility
+
+
+t : TranslationId -> String
+t resource =
+    Native.I18n.t resource

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -46,7 +46,7 @@ type MainModel
 
 
 type alias CommonPageState =
-    { settings : Settings, menu : Menu.Model, notice : Maybe Notice }
+    { settings : Settings, menu : Menu.Model, route : Route, notice : Maybe Notice }
 
 
 type PagedModel
@@ -249,10 +249,13 @@ mainUrlUpdate result mainModel =
                 userLocation =
                     (getUserLocation mainModel)
 
+                route =
+                    Routing.routeFromResult result
+
                 common =
-                    { settings = getSettings mainModel, menu = Menu.Closed, notice = notice mainModel }
+                    { settings = getSettings mainModel, menu = Menu.Closed, route = route, notice = notice mainModel }
             in
-                case Routing.routeFromResult result of
+                case route of
                     RootRoute ->
                         updatePagedModel HomeModel common <|
                             mapCmd HomeMsg <|
@@ -360,7 +363,7 @@ mainView mainModel =
         Page pagedModel common ->
             let
                 withLocale =
-                    prependToolbar (localeControlView common.settings)
+                    prependToolbar (localeControlView common.settings common.route)
 
                 withScale =
                     prependToolbar (scaleControlView (mapViewport mainModel).scale)
@@ -398,11 +401,14 @@ scaleControlView scale =
         ]
 
 
-localeControlView : Settings -> Html a
-localeControlView settings =
+localeControlView : Settings -> Route -> Html a
+localeControlView settings route =
     let
+        localeUrl lang =
+            Utils.setQuery ( "locale", lang ) (Routing.routeToPath route)
+
         localeAnchor ( key, name ) =
-            Html.a [ Html.Attributes.href ("/?locale=" ++ key), classList [ ( "active", key == settings.locale ) ] ]
+            Html.a [ Html.Attributes.href (localeUrl key), classList [ ( "active", key == settings.locale ) ] ]
                 [ Html.text name ]
     in
         div [ class "locales" ] <|

--- a/app/assets/javascripts/MainMenu.js.elm
+++ b/app/assets/javascripts/MainMenu.js.elm
@@ -9,6 +9,8 @@ import Html.App
 
 type alias Flags =
     { contactEmail : String
+    , locale : String
+    , locales : List ( String, String )
     }
 
 
@@ -23,7 +25,13 @@ main =
 
 
 init flags =
-    ( { fakeLocation = Nothing, contactEmail = flags.contactEmail }, Cmd.none )
+    ( { fakeLocation = Nothing
+      , contactEmail = flags.contactEmail
+      , locale = flags.locale
+      , locales = flags.locales
+      }
+    , Cmd.none
+    )
 
 
 update msg model =

--- a/app/assets/javascripts/Menu.elm
+++ b/app/assets/javascripts/Menu.elm
@@ -4,6 +4,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Shared exposing (icon)
 import Models exposing (Settings)
+import I18n exposing (..)
 
 
 type Model
@@ -41,20 +42,20 @@ menuContent settings active =
                 [ li []
                     [ a [ href "/", isActive Map ]
                         [ icon "map"
-                        , text "Map"
+                        , text <| t I18n.Map
                         ]
                     ]
                 , li []
                     [ a [ href "/docs", isActive ApiDoc ]
                         [ icon "code"
-                        , text "API Docs"
+                        , text <| t I18n.ApiDocs
                         ]
                     ]
                 , hr [] []
                 , li []
                     [ a [ href <| "mailto:" ++ settings.contactEmail ]
                         [ icon "email"
-                        , text "Contact"
+                        , text <| t I18n.Contact
                         ]
                     ]
                 ]

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -7,7 +7,11 @@ import String
 
 
 type alias Settings =
-    { fakeLocation : Maybe LatLng, contactEmail : String }
+    { fakeLocation : Maybe LatLng
+    , contactEmail : String
+    , locale : String
+    , locales : List ( String, String )
+    }
 
 
 type Route

--- a/app/assets/javascripts/Native/I18n.js
+++ b/app/assets/javascripts/Native/I18n.js
@@ -2,6 +2,6 @@ var _user$project$Native_I18n = {
   't': function(resource) {
     // http://stackoverflow.com/questions/30521224/javascript-convert-pascalcase-to-underscore-case
     var snake = resource.ctor.replace(/\.?([A-Z]+)/g, function (x,y){return "_" + y.toLowerCase()}).replace(/^_/, "");
-    return I18n.t(snake);
+    return I18n.t(snake, resource._0);
   }
 };

--- a/app/assets/javascripts/Native/I18n.js
+++ b/app/assets/javascripts/Native/I18n.js
@@ -1,0 +1,7 @@
+var _user$project$Native_I18n = {
+  't': function(resource) {
+    // http://stackoverflow.com/questions/30521224/javascript-convert-pascalcase-to-underscore-case
+    var snake = resource.ctor.replace(/\.?([A-Z]+)/g, function (x,y){return "_" + y.toLowerCase()}).replace(/^_/, "");
+    return I18n.t(snake);
+  }
+};

--- a/app/assets/javascripts/Routing.elm
+++ b/app/assets/javascripts/Routing.elm
@@ -1,4 +1,4 @@
-module Routing exposing (parser, navigate, routeFromResult)
+module Routing exposing (parser, navigate, routeFromResult, routeToPath)
 
 import Dict exposing (Dict)
 import Http
@@ -17,22 +17,23 @@ parser =
 
 navigate : Route -> Cmd msg
 navigate route =
-    let
-        url =
-            case route of
-                RootRoute ->
-                    "/"
+    Navigation.newUrl <| routeToPath route
 
-                SearchRoute params ->
-                    path "/search" params
 
-                FacilityRoute id ->
-                    "/facilities/" ++ (toString id)
+routeToPath : Route -> String
+routeToPath route =
+    case route of
+        RootRoute ->
+            "/"
 
-                NotFoundRoute ->
-                    "/not-found"
-    in
-        Navigation.newUrl url
+        SearchRoute params ->
+            path "/search" params
+
+        FacilityRoute id ->
+            "/facilities/" ++ (toString id)
+
+        NotFoundRoute ->
+            "/not-found"
 
 
 routeFromResult : Result String Route -> Route
@@ -65,36 +66,6 @@ matchers =
             , format makeSearchRoute (s "search")
             , format makeFacilityRoute (s "facilities" </> int)
             ]
-
-
-parseQuery : String -> Dict String String
-parseQuery query =
-    query
-        -- "?a=foo&b=bar&baz"
-        |>
-            String.dropLeft 1
-        -- "a=foo&b=bar&baz"
-        |>
-            String.split "&"
-        -- ["a=foo","b=bar","baz"]
-        |>
-            List.map parseParam
-        -- [[("a", "foo")], [("b", "bar")], []]
-        |>
-            List.concat
-        -- [("a", "foo"), ("b", "bar")]
-        |>
-            Dict.fromList
-
-
-parseParam : String -> List ( String, String )
-parseParam s =
-    case String.split "=" s of
-        k :: v :: [] ->
-            [ ( k, Http.uriDecode v ) ]
-
-        _ ->
-            []
 
 
 locationParser : Navigation.Location -> Result String Route

--- a/app/assets/javascripts/Shared.elm
+++ b/app/assets/javascripts/Shared.elm
@@ -7,6 +7,7 @@ import Html.Events as Events
 import Json.Decode
 import Models
 import String
+import I18n exposing (..)
 
 
 type alias LHtml a =
@@ -70,7 +71,7 @@ searchBar userInput submitMsg inputMsg trailing =
             [ Html.form [ action "#", method "GET", autocomplete False, Events.onSubmit submitMsg ]
                 [ input
                     [ type' "search"
-                    , placeholder "Search health facilities"
+                    , placeholder <| t SearchHealthFacility
                     , value userInput
                     , Events.onInput inputMsg
                     ]

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -8,6 +8,7 @@ import Html.Events exposing (onClick)
 import Models exposing (MapViewport)
 import String
 import Debounce
+import I18n exposing (..)
 
 
 type alias Config =
@@ -158,7 +159,7 @@ suggestion s =
                 [ icon "label"
                 , span [ class "title" ] [ text name ]
                 , p [ class "sub" ]
-                    [ text <| toString facilityCount ++ " facilities" ]
+                    [ text <| t (FacilitiesCount { count = facilityCount }) ]
                 ]
 
         Models.L { id, name, parentName } ->

--- a/app/assets/javascripts/Utils.elm
+++ b/app/assets/javascripts/Utils.elm
@@ -5,6 +5,7 @@ import String
 import Date exposing (Date)
 import Time
 import Task
+import Dict exposing (Dict)
 
 
 (&>) : Maybe a -> (a -> Maybe b) -> Maybe b
@@ -41,6 +42,57 @@ buildPath base queryParams =
                     |> List.map (\( k, v ) -> k ++ "=" ++ Http.uriEncode v)
                     |> String.join "&"
                 ]
+
+
+parseQuery : String -> Dict String String
+parseQuery query =
+    query
+        -- "?a=foo&b=bar&baz"
+        |>
+            String.dropLeft 1
+        -- "a=foo&b=bar&baz"
+        |>
+            String.split "&"
+        -- ["a=foo","b=bar","baz"]
+        |>
+            List.map parseParam
+        -- [[("a", "foo")], [("b", "bar")], []]
+        |>
+            List.concat
+        -- [("a", "foo"), ("b", "bar")]
+        |>
+            Dict.fromList
+
+
+parseParam : String -> List ( String, String )
+parseParam s =
+    case String.split "=" s of
+        k :: v :: [] ->
+            [ ( k, Http.uriDecode v ) ]
+
+        _ ->
+            []
+
+
+setQuery : ( String, String ) -> String -> String
+setQuery ( name, value ) url =
+    let
+        parts =
+            String.split "?" url
+
+        path =
+            Maybe.withDefault "" (List.head parts)
+
+        query =
+            "?" ++ (Maybe.withDefault "" (List.head (Maybe.withDefault [] (List.tail parts))))
+
+        queryDict =
+            parseQuery query
+
+        newQueryList =
+            Dict.toList <| Dict.union (Dict.singleton name value) queryDict
+    in
+        buildPath path newQueryList
 
 
 dateFromEpochSeconds : Float -> Date

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,6 @@
 //= require jquery_ujs
 //= require leaflet
 //= require leaflet.markercluster
+//= require i18n
+//= require i18n/translations
 //= require_tree .

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -120,6 +120,17 @@ nav .nav-wrapper {
       height: 4px;
     }
   }
+
+  .locales {
+    margin-right: 8px;
+    a {
+      color: black;
+      margin: 0 3px;
+    }
+    a.active {
+      font-weight: bold;
+    }
+  }
 }
 
 #TopNav {

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,5 +1,6 @@
 class ApiController < ActionController::Base
   protect_from_forgery with: :exception
+  before_filter :set_locale
 
   def search
     search_result = ElasticsearchService.instance.search_facilities(search_params)
@@ -34,5 +35,14 @@ class ApiController < ActionController::Base
 
   def search_params
     params.permit(:q, :s, :l, :lat, :lng, :size, :from)
+  end
+
+  def set_locale
+    begin
+      # if params or cookies are broken let's go with the default_locale
+      I18n.locale = params[:locale] || cookies[:locale] || http_accept_language.compatible_language_from(I18n.available_locales)
+    rescue
+      I18n.locale = I18n.default_locale
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_filter :set_locale
 
   skip_before_action :verify_authenticity_token, only: :report_facility
   before_action :set_js_flags
@@ -18,6 +19,16 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def set_locale
+    begin
+      # if params or cookies are broken let's go with the default_locale
+      I18n.locale = params[:locale] || cookies[:locale] || http_accept_language.compatible_language_from(I18n.available_locales)
+    rescue
+      I18n.locale = I18n.default_locale
+    end
+    cookies[:locale] = I18n.locale
+  end
+
   def set_js_flags
     @js_flags = {
       "initialPosition" => [Settings.initial_position.lat, Settings.initial_position.lng],
@@ -25,6 +36,8 @@ class ApplicationController < ActionController::Base
       "contactEmail" => Settings.report_email_to,
       "mapboxId" => Settings.mapbox_id,
       "mapboxToken" => Settings.mapbox_token,
+      "locales" => Settings.locales,
+      "locale" => I18n.locale,
     }
   end
 end

--- a/app/models/indexing.rb
+++ b/app/models/indexing.rb
@@ -90,7 +90,7 @@ class Indexing
           facility_types[type[:name]] = type
         end
 
-        f.merge({
+        f = f.merge({
           id: @last_facility_id += 1,
           source_id: f[:id],
           contact_phone: f[:contact_phone] && f[:contact_phone].to_s,
@@ -104,7 +104,6 @@ class Indexing
           },
 
           service_ids: services.map { |s| s[:id] },
-          service_names: services.map { |s| s[:name] },
 
           adm: location[:path_names],
           adm_ids: location[:path_ids],
@@ -112,6 +111,12 @@ class Indexing
           report_to: nil, # TODO
           last_updated: nil # TODO
         })
+
+        Settings.locales.to_h.each_key do |lang|
+          f["service_names:#{lang}".to_sym] = services.map { |s| s["name:#{lang}".to_sym] }.sort!
+        end
+
+        f
       end
 
       @service.index_facility_batch(index_entries)

--- a/app/views/docs/index.html.md
+++ b/app/views/docs/index.html.md
@@ -2,7 +2,7 @@
 
 ## i18n
 
-All API endpoints allows a `locale` parameter to specify the language or locale set to use. This affects the data returned and how to make searches: for example if English or Amharic versions of services' name should be used.
+All API endpoints allows a `locale` parameter to specify the language or locale set to use. This affects the data returned and how to make searches. For example, to specify whether to use English or Amharic names when requesting a facility detail, the following parameters can be used:
 
 | Value | Locale |
 |---|---|

--- a/app/views/docs/index.html.md
+++ b/app/views/docs/index.html.md
@@ -1,5 +1,19 @@
 # API
 
+## i18n
+
+All api endpoints allows a `locale` parameter to specify the language or locale set to use. This affects the data returned and how to make searches: for example if English or Amharic versions of services' name should be used.
+
+| Value | Locale |
+|---|---|
+| en | English |
+| am | Amharic |
+
+```
+$ curl 'vitalwave.instedd.org/api/facilities/85?locale=en'
+$ curl 'vitalwave.instedd.org/api/facilities/85?locale=am'
+```
+
 ## Discovery
 
 The suggest endpoint allows discovery in a human friendly manner. A response will include facilities, locations and services that match the search criteria.

--- a/app/views/docs/index.html.md
+++ b/app/views/docs/index.html.md
@@ -2,7 +2,7 @@
 
 ## i18n
 
-All api endpoints allows a `locale` parameter to specify the language or locale set to use. This affects the data returned and how to make searches: for example if English or Amharic versions of services' name should be used.
+All API endpoints allows a `locale` parameter to specify the language or locale set to use. This affects the data returned and how to make searches: for example if English or Amharic versions of services' name should be used.
 
 | Value | Locale |
 |---|---|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,11 @@
     <link href="//fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <%= render 'shared/favicomatic' %>
     <%= csrf_meta_tags %>
+    <script type="text/javascript">
+      I18n = {};
+      I18n.defaultLocale = "<%= I18n.default_locale %>";
+      I18n.locale = "<%= I18n.locale %>";
+    </script>
     <%= javascript_include_tag "application", media: 'all' %>
     <%= stylesheet_link_tag "application", media: 'all' %>
   </head>

--- a/bin/normalize-spa-data
+++ b/bin/normalize-spa-data
@@ -33,10 +33,44 @@ def write_output(filename, data, headers)
   puts "Writing #{full_filename}"
 
   CSV.open(full_filename, "wb") do |csv|
-    csv << headers
+    csv << csv_headers(headers)
     data.each do |f|
-      csv << headers.map { |h| f[h.to_sym] }
+      csv << headers.flat_map { |h| csv_value(h, f) }
     end
+  end
+end
+
+# if header has name:locale then name:loc1, name:loc2, ... name:locN is returned
+def csv_headers(headers)
+  headers.flat_map { |h|
+    name, locale = h.split ':'
+    if locale.nil?
+      name
+    else
+      Settings.locales.keys.map { |l| "name:#{l}" }
+    end
+  }
+end
+
+# if header has name:locale then name:loc1, name:loc2, ... name:locN values are returned using i18n for translation
+def csv_value(header, source_row)
+  name, locale = header.split ':'
+  raw_value = source_row[name.to_sym]
+  if locale.nil?
+    raw_value
+  else
+    Settings.locales.keys.map { |l| i18n_lookup(raw_value, locale.to_sym, l) }
+  end
+end
+
+$i18n_data = CSV.read(File.join(INPUT_PATH, "i18n.csv"), headers: true, header_converters: :symbol).map { |r| r.to_h }
+
+def i18n_lookup(text, source_lang, dest_lang)
+  if source_lang == dest_lang
+    text
+  else
+    row = $i18n_data.find { |d| d[source_lang] == text }
+    row.try { |row| row[dest_lang] } || "[missing #{dest_lang}: #{text}]"
   end
 end
 
@@ -57,7 +91,7 @@ end
 result = SpaNormalization.new(dataset).run
 
 write_output "facilities.csv", result[:facilities], ["id", "name", "lat", "lng", "location_id", "facility_type", "contact_name", "contact_email", "contact_phone", "last"]
-write_output "services.csv", result[:services], ["id", "name"]
+write_output "services.csv", result[:services], ["id", "name:en"]
 write_output "facilities_services.csv", result[:facilities_services], ["facility_id", "service_id"]
 write_output "facility_types.csv", result[:facility_types], ["name", "priority"]
 write_output "locations.csv", result[:locations], ["id", "name", "parent_id"]

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
     # Compiling Elm assets from scratch when building the docker image takes ~15 minutes.
     # To avoid this wait time every time we build the image, we compile assets here, cache
     # compiled dependencies and then tell the docker build to skip assets compilation.
-    - bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=secret:
+    - ./docker/precompile-assets.sh:
         timeout: 1200
   cache_directories:
     - "elm-stuff/build-artifacts"

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,8 @@ module FPP
     config.middleware.use Rack::Deflater
 
     config.middleware.use I18n::JS::Middleware
+
+    config.i18n.default_locale = Settings.default_locale.to_sym
+    config.i18n.available_locales = Settings.locales.keys
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,5 +12,7 @@ module FPP
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.middleware.use Rack::Deflater
+
+    config.middleware.use I18n::JS::Middleware
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,8 +13,6 @@ module FPP
     # -- all .rb files in that directory are automatically loaded.
     config.middleware.use Rack::Deflater
 
-    config.middleware.use I18n::JS::Middleware
-
     config.i18n.default_locale = Settings.default_locale.to_sym
     config.i18n.available_locales = Settings.locales.keys
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,4 +54,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.middleware.use I18n::JS::Middleware
 end

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -1,0 +1,27 @@
+# Split context in several files.
+#
+# By default only one file with all translations is exported and
+# no configuration is required. Your settings for asset pipeline
+# are automatically recognized.
+#
+# If you want to split translations into several files or specify
+# locale contexts that will be exported, just use this file to do
+# so.
+#
+# For more informations about the export options with this file, please
+# refer to the README
+#
+#
+# If you're going to use the Rails 3.1 asset pipeline, change
+# the following configuration to something like this:
+#
+# translations:
+#   - file: "app/assets/javascripts/i18n/translations.js"
+#
+# If you're running an old version, you can use something
+# like this:
+#
+# translations:
+#   - file: "app/assets/javascripts/i18n/translations.js"
+#     only: "*"
+#

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -15,8 +15,8 @@
 # If you're going to use the Rails 3.1 asset pipeline, change
 # the following configuration to something like this:
 #
-# translations:
-#   - file: "app/assets/javascripts/i18n/translations.js"
+translations:
+  - file: "app/assets/javascripts/i18n/translations.js"
 #
 # If you're running an old version, you can use something
 # like this:
@@ -25,3 +25,5 @@
 #   - file: "app/assets/javascripts/i18n/translations.js"
 #     only: "*"
 #
+
+export_i18n_js: "app/assets/javascripts/i18n"

--- a/config/locales/am.yml
+++ b/config/locales/am.yml
@@ -1,0 +1,8 @@
+am:
+  search_health_facility: የፍለጋ የጤና ተቋማት
+  map: ካርታ
+  api_docs: የኤ ፒ አይ ሰነዶች
+  contact: እውቂያ
+  services: አገልግሎቶች
+  facilities_count: "%{count} መገልገያዎች"
+  report_an_issue: ችግር ሪፖርት አድርግ

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,4 @@ en:
   map: Map
   api_docs: API Docs
   contact: Contact
+  facilities_count: "%{count} facilities"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,5 +24,6 @@ en:
   map: Map
   api_docs: API Docs
   contact: Contact
+  services: Services
   facilities_count: "%{count} facilities"
   report_an_issue: Report an issue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,3 +25,4 @@ en:
   api_docs: API Docs
   contact: Contact
   facilities_count: "%{count} facilities"
+  report_an_issue: Report an issue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  search_health_facility: "Search health facilities"
+  search_health_facility: Search health facilities
+  map: Map
+  api_docs: API Docs
+  contact: Contact

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,4 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  search_health_facility: "Search health facilities"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3,3 +3,4 @@ es:
   map: Mapa
   api_docs: Documentación API
   contact: Contacto
+  facilities_count: "%{count} centros de salud"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,2 @@
+es:
+  search_health_facility: "Buscar centros de salud"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,2 +1,5 @@
 es:
-  search_health_facility: "Buscar centros de salud"
+  search_health_facility: Buscar centros de salud
+  map: Mapa
+  api_docs: Documentación API
+  contact: Contacto

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,6 +2,7 @@ es:
   search_health_facility: Buscar centros de salud
   map: Mapa
   api_docs: Documentación API
+  services: Servicos
   contact: Contacto
   facilities_count: "%{count} centros de salud"
   report_an_issue: Reportar un problema

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,3 +4,4 @@ es:
   api_docs: Documentación API
   contact: Contacto
   facilities_count: "%{count} centros de salud"
+  report_an_issue: Reportar un problema

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,6 @@ initial_position:
 user_position: fake
 mapbox_id: "mapbox/streets-v9"
 mapbox_token: "pk.eyJ1IjoibWZyIiwiYSI6ImNpdDBieTFhdzBsZ3gyemtoMmlpODAzYTEifQ.S9MV3eZjN39ZXh_G5_2gWQ"
+default_locale: en
+locales:
+  en: English

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,3 @@
 locales:
   es: Español
+  # am: አማርኛ

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+locales:
+  es: Español

--- a/docker/precompile-assets.sh
+++ b/docker/precompile-assets.sh
@@ -2,6 +2,16 @@
 set -euo pipefail
 
 
-if ! [[ -v SKIP_ASSETS_COMPILATION ]]; then
+if [[ -z ${SKIP_ASSETS_COMPILATION+x} ]]; then
+    # Define locales that should be available on js assets
+    # for safety, all locales in ./config/locales/*.yml
+    RAILS_ENV=production \
+      SETTINGS__LOCALES__EN=English \
+      SETTINGS__LOCALES__ES=Español \
+      SETTINGS__LOCALES__AM=አማርኛ \
+      bundle exec rake i18n:js:export
+
     bundle exec rake assets:precompile RAILS_ENV=production SECRET_KEY_BASE=secret
+
+    echo "done"
 fi

--- a/elm-package.json
+++ b/elm-package.json
@@ -6,6 +6,7 @@
     "source-directories": [
         "./app/assets/javascripts"
     ],
+    "native-modules": true,
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",

--- a/spec/elasticsearch_service_spec.rb
+++ b/spec/elasticsearch_service_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe ElasticsearchService do
                    ],
 
                    services: [
-                     { id: "S1", name: "service1" },
-                     { id: "S2", name: "service2" },
-                     { id: "S3", name: "service3" }
+                     { id: "S1", "name:en": "service1" },
+                     { id: "S2", "name:en": "service2" },
+                     { id: "S3", "name:en": "service3" }
                    ],
 
                    facilities_services: [


### PR DESCRIPTION
fix #26 

## i18n UI 
./config/locales/*.yml entries are transformed to js assets thanks to i18n-js gem.
An elm module I18n contains a list of `TranslationId` which are able to interpolate strings.
A `t : TranslationId -> String` is used to get the string in the current locale (as managed by i18n-js). (A custom native module does the bridge)

## i18n in data
Currently only services names are translated. The spa normalization asumes there is a `i18n.csv` with the equivalence:

|en|es|am|
|---|---|---|
|text in english|texto en español|አማርኛ ውስጥ ጽሑፍ|

In `./bin/normalize-spa-data`:
```
...
write_output "services.csv", result[:services], ["id", "name:en"]
...
```

Specifies that the name column of `services.csv` is written in english and should be normalized including all available locales by looking up the exact texts in i18n.csv .

The generated `data/input/services.csv` file will be:

```
id,name:en,name:es,name:am
D7A1CE19-84B5-4F95-AB10-00D03D18570D,Efavirenz (efv) tablets/capsules,Efavirenz (EFV) tabletas / cápsulas,Efavirenz (efv) ጽላቶች / እንክብልና
```

There will be a `name:LOCALE`  column for each of the available locales.

## Choosing locale

The api allows `?locale=LOCALE` in the query string but also a cookie is used. See `ApiController#set_locale`. Only the service names of the selected locale will be returned as "name".

For UI the `ApplicationController#set_locale` determines the locale by the following priority:
1. query string
2. cookie
3. browse accepted languages
4. app default locale 

When a UI request returns a cookie is set with the last locale.

This cookie is used for api calls, so if multiple tabs are used with different languages the behavior will be misleading.

## ElasticSearch

The service name are stored in different fields "name:en", "name:es", "name:am".

The ElasticsearchService will use the current local to project the appropriate name only (`ElasticsearchService#keep_i18n_field`) and make the searches using the appropriate field  (`ElasticsearchService#i18n_key`)

## Available locales

The Settings.yml determine the available locales.  Default english only. Development +spanish.
For production `SETTINGS__LOCALES__AM=አማርኛ` can be used to enable more locales. 

## Deployment

`rake i18n:js:export` is used to generate all js resources for ALL locales (./docker/precompile-assets.sh) then the assets are precompiled as usual. Assets are included even if the locale is not available via env variables when the app is running.

## Development

A middleware generates the i18n assets on the fly to `app/assets/javascripts/i18n/` which is now in .gitignore
