### PR TITLE
Refactor: tidy up composition of (model, cmd) structures

### DIFF
--- a/app/assets/javascripts/UserLocation.elm
+++ b/app/assets/javascripts/UserLocation.elm
@@ -1,7 +1,6 @@
 module UserLocation exposing (Model, Msg, init, update, view)
 
 import Models exposing (LatLng, Settings)
-import Utils exposing (mapFst)
 import Geolocation
 import Map
 import Process

--- a/app/assets/javascripts/Utils.elm
+++ b/app/assets/javascripts/Utils.elm
@@ -13,21 +13,6 @@ import Dict exposing (Dict)
     Maybe.andThen
 
 
-mapFst : (a -> b) -> ( a, c ) -> ( b, c )
-mapFst f ( a, c ) =
-    ( f a, c )
-
-
-mapSnd : (b -> c) -> ( a, b ) -> ( a, c )
-mapSnd f ( a, b ) =
-    ( a, f b )
-
-
-mapTCmd : (a -> c) -> (b -> d) -> ( a, Cmd b ) -> ( c, Cmd d )
-mapTCmd f g ( a, b ) =
-    ( f a, Cmd.map g b )
-
-
 buildPath : String -> List ( String, String ) -> String
 buildPath base queryParams =
     case queryParams of

--- a/elm-package.json
+++ b/elm-package.json
@@ -6,9 +6,10 @@
     "source-directories": [
         "./app/assets/javascripts"
     ],
-    "native-modules": true,
     "exposed-modules": [],
+    "native-modules": true,
     "dependencies": {
+        "Fresheyeball/elm-return": "4.0.0 <= v < 5.0.0",
         "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",
         "bcardiff/elm-debounce": "1.1.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.5 <= v < 5.0.0",


### PR DESCRIPTION
Use [elm-return](http://package.elm-lang.org/packages/Fresheyeball/elm-return/4.0.0) to make composition of (model, cmd) structures easier to read.