### PR TITLE
Filter by admin location

### DIFF
--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -1,14 +1,22 @@
-module AdvancedSearch exposing (Model, Msg(..), PrivateMsg, init, update, subscriptions, view)
+module AdvancedSearch
+    exposing
+        ( Model
+        , Msg(..)
+        , init
+        , update
+        , subscriptions
+        , view
+        )
 
 import Html exposing (..)
 import Html.App
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onInput)
-import Models exposing (SearchSpec, FacilityType, Ownership, Location, emptySearch, setType, setQuery, setOwnership)
-import Return exposing (Return)
-import Shared
-import LocationSelector
+import Html.Events exposing (onInput)
 import Json.Decode as Json
+import LocationSelector
+import Models exposing (SearchSpec, FacilityType, Ownership, Location, emptySearch)
+import Return exposing (Return)
+import Shared exposing (onClick)
 
 
 type alias Model =
@@ -66,7 +74,7 @@ update model msg =
             Return.singleton { model | selector = (LocationSelector.close model.selector) }
 
         _ ->
-            -- To be handled by host page
+            -- Public events
             Return.singleton model
 
 
@@ -83,7 +91,7 @@ view model =
     in
         Shared.modalWindow
             [ text "Advanced Search"
-            , a [ href "#", class "right", Shared.onClick Toggle ] [ Shared.icon "close" ]
+            , a [ href "#", class "right", onClick Toggle ] [ Shared.icon "close" ]
             ]
             [ Html.form [ action "#", method "GET" ]
                 [ field
@@ -108,7 +116,7 @@ view model =
                 [ href "#"
                 , class "btn-flat"
                 , hideSelectorOnFocus
-                , Shared.onClick (Perform (search model))
+                , onClick (Perform (search model))
                 ]
                 [ text "Search" ]
             ]

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -1,0 +1,99 @@
+module AdvancedSearch exposing (Model, Msg(..), PrivateMsg, init, update, view)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick, onInput)
+import Models exposing (SearchSpec, FacilityType, Ownership, Location, setType, setQuery, setOwnership)
+import Return exposing (Return)
+import Shared
+
+
+type alias Model =
+    { search : SearchSpec }
+
+
+type Msg
+    = Toggle
+    | Perform SearchSpec
+    | Private PrivateMsg
+
+
+type PrivateMsg
+    = SetName String
+    | SetType Int
+    | SetOwnership Int
+
+
+init : Model
+init =
+    { search = Models.emptySearch }
+
+
+update : Model -> Msg -> Return Msg Model
+update model msg =
+    case msg of
+        Private (SetName q) ->
+            model
+                |> updateSearch setQuery q
+                |> Return.singleton
+
+        Private (SetType fType) ->
+            model
+                |> updateSearch setType fType
+                |> Return.singleton
+
+        Private (SetOwnership o) ->
+            model
+                |> updateSearch setOwnership o
+                |> Return.singleton
+
+        _ ->
+            -- To be handled by host page
+            Return.singleton model
+
+
+updateSearch : (a -> SearchSpec -> SearchSpec) -> a -> Model -> Model
+updateSearch f x model =
+    { model | search = f x model.search }
+
+
+view : Model -> List FacilityType -> List Ownership -> List (Html Msg)
+view model types ownerships =
+    let
+        search =
+            model.search
+
+        query =
+            Maybe.withDefault "" search.q
+    in
+        Shared.modalWindow
+            [ text "Advanced Search"
+            , a [ href "#", class "right", Shared.onClick Toggle ] [ Shared.icon "close" ]
+            ]
+            [ Html.form [ action "#", method "GET" ]
+                [ label [ for "q" ] [ text "Facility name" ]
+                , input [ id "q", type' "text", value query, onInput (Private << SetName) ] []
+                , label [] [ text "Facility type" ]
+                , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions types search.fType)
+                , label [] [ text "Ownership" ]
+                , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions ownerships search.ownership)
+                ]
+            ]
+            [ a [ href "#", class "btn-flat", Shared.onClick (Perform search) ] [ text "Search" ] ]
+
+
+selectOptions : List { id : Int, name : String } -> Maybe Int -> List (Html a)
+selectOptions options choice =
+    let
+        selectedId =
+            Maybe.withDefault 0 choice
+    in
+        [ Html.option [ value "0" ] [ text "" ] ]
+            ++ (List.map
+                    (\option ->
+                        Html.option
+                            [ value (toString option.id), selected (option.id == selectedId) ]
+                            [ text option.name ]
+                    )
+                    options
+               )

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -33,8 +33,8 @@ type PrivateMsg
     | SelectorMsg LocationSelector.Msg
 
 
-init : List FacilityType -> List Ownership -> Model
-init facilityTypes ownerships =
+init : List FacilityType -> List Ownership -> List Location -> Model
+init facilityTypes ownerships locations =
     { facilityTypes = facilityTypes
     , ownerships = ownerships
     , q = Nothing
@@ -119,10 +119,3 @@ selectOptions options choice =
                     )
                     options
                )
-
-
-locations : List Location
-locations =
-    [ { id = 1, name = "Foo", parentName = Nothing }
-    , { id = 2, name = "Bar", parentName = Just "Foo" }
-    ]

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -8,6 +8,7 @@ import Models exposing (SearchSpec, FacilityType, Ownership, Location, emptySear
 import Return exposing (Return)
 import Shared
 import LocationSelector
+import Json.Decode as Json
 
 
 type alias Model =
@@ -31,6 +32,7 @@ type PrivateMsg
     | SetType Int
     | SetOwnership Int
     | SelectorMsg LocationSelector.Msg
+    | HideSelector
 
 
 init : List FacilityType -> List Ownership -> List Location -> Model
@@ -59,6 +61,9 @@ update model msg =
         Private (SelectorMsg msg) ->
             LocationSelector.update msg model.selector
                 |> Return.mapBoth (Private << SelectorMsg) (\m -> { model | selector = m })
+
+        Private HideSelector ->
+            Return.singleton { model | selector = (LocationSelector.close model.selector) }
 
         _ ->
             -- To be handled by host page
@@ -99,12 +104,25 @@ view model =
                     ]
                 ]
             ]
-            [ a [ href "#", class "btn-flat", Shared.onClick (Perform (search model)) ] [ text "Search" ] ]
+            [ a
+                [ href "#"
+                , class "btn-flat"
+                , hideSelectorOnFocus
+                , Shared.onClick (Perform (search model))
+                ]
+                [ text "Search" ]
+            ]
 
 
 field : List (Html Msg) -> Html Msg
 field content =
-    div [ class "field" ] content
+    div
+        [ class "field", hideSelectorOnFocus ]
+        content
+
+
+hideSelectorOnFocus =
+    Html.Events.on "focusin" (Json.succeed <| Private HideSelector)
 
 
 search : Model -> SearchSpec

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -1,15 +1,21 @@
-module AdvancedSearch exposing (Model, Msg(..), PrivateMsg, init, update, view)
+module AdvancedSearch exposing (Model, Msg(..), PrivateMsg, init, update, subscriptions, view)
 
 import Html exposing (..)
+import Html.App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
-import Models exposing (SearchSpec, FacilityType, Ownership, Location, setType, setQuery, setOwnership)
+import Models exposing (SearchSpec, FacilityType, Ownership, Location, emptySearch, setType, setQuery, setOwnership)
 import Return exposing (Return)
 import Shared
+import LocationSelector
 
 
 type alias Model =
-    { search : SearchSpec }
+    { q : Maybe String
+    , fType : Maybe Int
+    , ownership : Maybe Int
+    , selector : LocationSelector.Model
+    }
 
 
 type Msg
@@ -22,49 +28,49 @@ type PrivateMsg
     = SetName String
     | SetType Int
     | SetOwnership Int
+    | SelectorMsg LocationSelector.Msg
 
 
 init : Model
 init =
-    { search = Models.emptySearch }
+    { q = Nothing
+    , fType = Nothing
+    , ownership = Nothing
+    , selector = LocationSelector.init locations
+    }
 
 
 update : Model -> Msg -> Return Msg Model
 update model msg =
     case msg of
         Private (SetName q) ->
-            model
-                |> updateSearch setQuery q
-                |> Return.singleton
+            Return.singleton { model | q = Just q }
 
         Private (SetType fType) ->
-            model
-                |> updateSearch setType fType
-                |> Return.singleton
+            Return.singleton { model | fType = Just fType }
 
         Private (SetOwnership o) ->
-            model
-                |> updateSearch setOwnership o
-                |> Return.singleton
+            Return.singleton { model | ownership = Just o }
+
+        Private (SelectorMsg msg) ->
+            LocationSelector.update msg model.selector
+                |> Return.mapBoth (Private << SelectorMsg) (\m -> { model | selector = m })
 
         _ ->
             -- To be handled by host page
             Return.singleton model
 
 
-updateSearch : (a -> SearchSpec -> SearchSpec) -> a -> Model -> Model
-updateSearch f x model =
-    { model | search = f x model.search }
+subscriptions : Sub Msg
+subscriptions =
+    Sub.map (Private << SelectorMsg) LocationSelector.subscriptions
 
 
 view : Model -> List FacilityType -> List Ownership -> List (Html Msg)
 view model types ownerships =
     let
-        search =
-            model.search
-
         query =
-            Maybe.withDefault "" search.q
+            Maybe.withDefault "" model.q
     in
         Shared.modalWindow
             [ text "Advanced Search"
@@ -74,12 +80,24 @@ view model types ownerships =
                 [ label [ for "q" ] [ text "Facility name" ]
                 , input [ id "q", type' "text", value query, onInput (Private << SetName) ] []
                 , label [] [ text "Facility type" ]
-                , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions types search.fType)
+                , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions types model.fType)
                 , label [] [ text "Ownership" ]
-                , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions ownerships search.ownership)
+                , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions ownerships model.ownership)
+                , label [] [ text "Location" ]
+                , Html.App.map (Private << SelectorMsg) (LocationSelector.view model.selector)
                 ]
             ]
-            [ a [ href "#", class "btn-flat", Shared.onClick (Perform search) ] [ text "Search" ] ]
+            [ a [ href "#", class "btn-flat", Shared.onClick (Perform (search model)) ] [ text "Search" ] ]
+
+
+search : Model -> SearchSpec
+search model =
+    { emptySearch
+        | q = model.q
+        , location = Maybe.map .id model.selector.selectedLocation
+        , fType = model.fType
+        , ownership = model.ownership
+    }
 
 
 selectOptions : List { id : Int, name : String } -> Maybe Int -> List (Html a)
@@ -97,3 +115,10 @@ selectOptions options choice =
                     )
                     options
                )
+
+
+locations : List Location
+locations =
+    [ { id = 1, name = "Foo", parentName = Nothing }
+    , { id = 2, name = "Bar", parentName = Just "Foo" }
+    ]

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -81,17 +81,30 @@ view model =
             , a [ href "#", class "right", Shared.onClick Toggle ] [ Shared.icon "close" ]
             ]
             [ Html.form [ action "#", method "GET" ]
-                [ label [ for "q" ] [ text "Facility name" ]
-                , input [ id "q", type' "text", value query, onInput (Private << SetName) ] []
-                , label [] [ text "Facility type" ]
-                , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions model.facilityTypes model.fType)
-                , label [] [ text "Ownership" ]
-                , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions model.ownerships model.ownership)
-                , label [] [ text "Location" ]
-                , Html.App.map (Private << SelectorMsg) (LocationSelector.view model.selector)
+                [ field
+                    [ label [ for "q" ] [ text "Facility name" ]
+                    , input [ id "q", type' "text", value query, onInput (Private << SetName) ] []
+                    ]
+                , field
+                    [ label [] [ text "Facility type" ]
+                    , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions model.facilityTypes model.fType)
+                    ]
+                , field
+                    [ label [] [ text "Ownership" ]
+                    , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions model.ownerships model.ownership)
+                    ]
+                , field
+                    [ label [] [ text "Location" ]
+                    , Html.App.map (Private << SelectorMsg) (LocationSelector.view model.selector)
+                    ]
                 ]
             ]
             [ a [ href "#", class "btn-flat", Shared.onClick (Perform (search model)) ] [ text "Search" ] ]
+
+
+field : List (Html Msg) -> Html Msg
+field content =
+    div [ class "field" ] content
 
 
 search : Model -> SearchSpec

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -11,7 +11,9 @@ import LocationSelector
 
 
 type alias Model =
-    { q : Maybe String
+    { facilityTypes : List FacilityType
+    , ownerships : List Ownership
+    , q : Maybe String
     , fType : Maybe Int
     , ownership : Maybe Int
     , selector : LocationSelector.Model
@@ -31,9 +33,11 @@ type PrivateMsg
     | SelectorMsg LocationSelector.Msg
 
 
-init : Model
-init =
-    { q = Nothing
+init : List FacilityType -> List Ownership -> Model
+init facilityTypes ownerships =
+    { facilityTypes = facilityTypes
+    , ownerships = ownerships
+    , q = Nothing
     , fType = Nothing
     , ownership = Nothing
     , selector = LocationSelector.init locations
@@ -66,8 +70,8 @@ subscriptions =
     Sub.map (Private << SelectorMsg) LocationSelector.subscriptions
 
 
-view : Model -> List FacilityType -> List Ownership -> List (Html Msg)
-view model types ownerships =
+view : Model -> List (Html Msg)
+view model =
     let
         query =
             Maybe.withDefault "" model.q
@@ -80,9 +84,9 @@ view model types ownerships =
                 [ label [ for "q" ] [ text "Facility name" ]
                 , input [ id "q", type' "text", value query, onInput (Private << SetName) ] []
                 , label [] [ text "Facility type" ]
-                , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions types model.fType)
+                , Html.select [ Shared.onSelect (Private << SetType) ] (selectOptions model.facilityTypes model.fType)
                 , label [] [ text "Ownership" ]
-                , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions ownerships model.ownership)
+                , Html.select [ Shared.onSelect (Private << SetOwnership) ] (selectOptions model.ownerships model.ownership)
                 , label [] [ text "Location" ]
                 , Html.App.map (Private << SelectorMsg) (LocationSelector.view model.selector)
                 ]

--- a/app/assets/javascripts/AppHome.elm
+++ b/app/assets/javascripts/AppHome.elm
@@ -166,6 +166,7 @@ subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
         [ Sub.map (Private << MapMsg) Map.subscriptions
+        , Sub.map (Private << SuggestMsg) Suggest.subscriptions
         , Map.facilityMarkerClicked FacilityClicked
         ]
 

--- a/app/assets/javascripts/AppHome.elm
+++ b/app/assets/javascripts/AppHome.elm
@@ -17,8 +17,6 @@ type alias Model =
     , mapViewport : MapViewport
     , userLocation : UserLocation.Model
     , d : Debounce.State
-    , facilityTypes : List FacilityType
-    , ownerships : List Ownership
     }
 
 
@@ -45,12 +43,10 @@ init : Settings -> MapViewport -> UserLocation.Model -> ( Model, Cmd Msg )
 init settings mapViewport userLocation =
     let
         model =
-            { suggest = Suggest.empty
+            { suggest = Suggest.empty settings
             , mapViewport = mapViewport
             , userLocation = userLocation
             , d = Debounce.init
-            , facilityTypes = settings.facilityTypes
-            , ownerships = settings.ownerships
             }
     in
         model
@@ -146,7 +142,7 @@ view model =
     , content = suggestionInput model :: (suggestionItems model)
     , toolbar = [ userLocationView model ]
     , bottom = []
-    , modal = List.map (Html.App.map (Private << SuggestMsg)) (Suggest.advancedSearchWindow model.suggest model.facilityTypes model.ownerships)
+    , modal = List.map (Html.App.map (Private << SuggestMsg)) (Suggest.advancedSearchWindow model.suggest)
     }
 
 

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -23,8 +23,6 @@ type alias Model =
     , results : Maybe SearchResult
     , mobileFocusMap : Bool
     , d : Debounce.State
-    , facilityTypes : List FacilityType
-    , ownerships : List Ownership
     }
 
 
@@ -59,15 +57,13 @@ init : Settings -> SearchSpec -> MapViewport -> UserLocation.Model -> ( Model, C
 init s query mapViewport userLocation =
     let
         model =
-            { suggest = Suggest.init (queryText query)
+            { suggest = Suggest.init s (queryText query)
             , query = query
             , mapViewport = mapViewport
             , userLocation = userLocation
             , results = Nothing
             , mobileFocusMap = True
             , d = Debounce.init
-            , facilityTypes = s.facilityTypes
-            , ownerships = s.ownerships
             }
     in
         model
@@ -222,7 +218,7 @@ view model =
                 [ mobileFocusToggleView ]
             else
                 []
-        , modal = List.map (Html.App.map (Private << SuggestMsg)) (Suggest.advancedSearchWindow model.suggest model.facilityTypes model.ownerships)
+        , modal = List.map (Html.App.map (Private << SuggestMsg)) (Suggest.advancedSearchWindow model.suggest)
         }
 
 
@@ -237,6 +233,7 @@ mobileBackHeader =
             , span [] [ text "Search Results" ]
             ]
         ]
+
 
 
 -- Keeping this here for when adv search is extracted from suggest, to edit it.

--- a/app/assets/javascripts/LocationSelector.elm
+++ b/app/assets/javascripts/LocationSelector.elm
@@ -1,0 +1,308 @@
+module LocationSelector exposing (..)
+
+import Autocomplete
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Html.App as Html
+import String
+import Json.Decode as Json
+import Dom
+import Task
+import Models exposing (Location)
+import Utils exposing ((&>))
+
+
+subscriptions : Sub Msg
+subscriptions =
+    Sub.map SetAutoState Autocomplete.subscription
+
+
+type alias Model =
+    { locations : List Location
+    , autoState : Autocomplete.State
+    , howManyToShow : Int
+    , query : String
+    , selectedLocation : Maybe Location
+    , showMenu : Bool
+    }
+
+
+init : List Location -> Model
+init locations =
+    { locations = locations
+    , autoState = Autocomplete.empty
+    , howManyToShow = 5
+    , query = ""
+    , selectedLocation = Nothing
+    , showMenu = False
+    }
+
+
+type Msg
+    = SetQuery String
+    | SetAutoState Autocomplete.Msg
+    | Wrap Bool
+    | Reset
+    | HandleEscape
+    | SelectLocationKeyboard Int
+    | SelectLocationMouse Int
+    | PreviewLocation Int
+    | OnFocus
+    | NoOp
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        SetQuery newQuery ->
+            let
+                showMenu =
+                    not << List.isEmpty <| (acceptableLocations newQuery model.locations)
+            in
+                { model | query = newQuery, showMenu = showMenu, selectedLocation = Nothing } ! []
+
+        SetAutoState autoMsg ->
+            let
+                ( newState, maybeMsg ) =
+                    Autocomplete.update updateConfig autoMsg model.howManyToShow model.autoState (acceptableLocations model.query model.locations)
+
+                newModel =
+                    { model | autoState = newState }
+            in
+                case maybeMsg of
+                    Nothing ->
+                        newModel ! []
+
+                    Just updateMsg ->
+                        update updateMsg newModel
+
+        HandleEscape ->
+            let
+                validOptions =
+                    not <| List.isEmpty (acceptableLocations model.query model.locations)
+
+                handleEscape =
+                    if validOptions then
+                        model
+                            |> removeSelection
+                            |> resetMenu
+                    else
+                        { model | query = "" }
+                            |> removeSelection
+                            |> resetMenu
+
+                escapedModel =
+                    case model.selectedLocation of
+                        Just location ->
+                            if model.query == location.name then
+                                model
+                                    |> resetInput
+                            else
+                                handleEscape
+
+                        Nothing ->
+                            handleEscape
+            in
+                escapedModel ! []
+
+        Wrap toTop ->
+            case model.selectedLocation of
+                Just location ->
+                    update Reset model
+
+                Nothing ->
+                    if toTop then
+                        { model
+                            | autoState = Autocomplete.resetToLastItem updateConfig (acceptableLocations model.query model.locations) model.howManyToShow model.autoState
+                            , selectedLocation = List.head <| List.reverse <| List.take model.howManyToShow <| (acceptableLocations model.query model.locations)
+                        }
+                            ! []
+                    else
+                        { model
+                            | autoState = Autocomplete.resetToFirstItem updateConfig (acceptableLocations model.query model.locations) model.howManyToShow model.autoState
+                            , selectedLocation = List.head <| List.take model.howManyToShow <| (acceptableLocations model.query model.locations)
+                        }
+                            ! []
+
+        Reset ->
+            { model | autoState = Autocomplete.reset updateConfig model.autoState, selectedLocation = Nothing } ! []
+
+        SelectLocationKeyboard id ->
+            let
+                newModel =
+                    setQuery model id
+                        |> resetMenu
+            in
+                newModel ! []
+
+        SelectLocationMouse id ->
+            let
+                newModel =
+                    setQuery model id
+                        |> resetMenu
+            in
+                ( newModel, Task.perform (\err -> NoOp) (\_ -> NoOp) (Dom.focus "location-input") )
+
+        PreviewLocation id ->
+            { model | selectedLocation = Just <| getLocationAtId model.locations id } ! []
+
+        OnFocus ->
+            model ! []
+
+        NoOp ->
+            model ! []
+
+
+resetInput model =
+    { model | query = "" }
+        |> removeSelection
+        |> resetMenu
+
+
+removeSelection model =
+    { model | selectedLocation = Nothing }
+
+
+getLocationAtId locations id =
+    List.filter (\location -> location.id == id) locations
+        |> List.head
+        |> -- TODO: crash on default?
+           Maybe.withDefault ({ id = 0, name = "", parentName = Nothing })
+
+
+setQuery model id =
+    { model
+        | query = .name <| getLocationAtId model.locations id
+        , selectedLocation = Just <| getLocationAtId model.locations id
+    }
+
+
+resetMenu model =
+    { model
+        | autoState = Autocomplete.empty
+        , showMenu = False
+    }
+
+
+view : Model -> Html Msg
+view model =
+    let
+        options =
+            { preventDefault = True, stopPropagation = False }
+
+        dec =
+            (Json.customDecoder keyCode
+                (\code ->
+                    if code == 38 || code == 40 then
+                        Ok NoOp
+                    else if code == 27 then
+                        Ok HandleEscape
+                    else
+                        Err "not handling that key"
+                )
+            )
+
+        menu =
+            if model.showMenu then
+                [ viewMenu model ]
+            else
+                []
+
+        query =
+            case model.selectedLocation of
+                Just location ->
+                    location.name
+
+                Nothing ->
+                    model.query
+    in
+        div []
+            (List.append
+                [ input
+                    [ onInput SetQuery
+                    , onFocus OnFocus
+                    , onWithOptions "keydown" options dec
+                    , value query
+                    , id "location-input"
+                    , class "autocomplete-input"
+                    , autocomplete False
+                    , attribute "role" "combobox"
+                    ]
+                    []
+                ]
+                menu
+            )
+
+
+acceptableLocations : String -> List Location -> List Location
+acceptableLocations query locations =
+    let
+        lowerQuery =
+            String.toLower query
+    in
+        List.filter (String.contains lowerQuery << String.toLower << .name) locations
+
+
+viewMenu : Model -> Html Msg
+viewMenu model =
+    div [ class "autocomplete-menu" ]
+        [ Html.map SetAutoState (Autocomplete.view viewConfig model.howManyToShow model.autoState (acceptableLocations model.query model.locations)) ]
+
+
+updateConfig : Autocomplete.UpdateConfig Msg Location
+updateConfig =
+    Autocomplete.updateConfig
+        { toId =
+            .id >> toString
+        , onKeyDown =
+            \code maybeId ->
+                if code == 38 || code == 40 then
+                    maybeId
+                        &> parseId
+                        |> Maybe.map PreviewLocation
+                else if code == 13 then
+                    maybeId
+                        &> parseId
+                        |> Maybe.map SelectLocationKeyboard
+                else
+                    Just <| Reset
+        , onTooLow =
+            Just <| Wrap False
+        , onTooHigh =
+            Just <| Wrap True
+        , onMouseEnter =
+            parseId >> Maybe.map PreviewLocation
+        , onMouseLeave =
+            \_ -> Nothing
+        , onMouseClick =
+            parseId >> Maybe.map SelectLocationMouse
+        , separateSelections = False
+        }
+
+
+viewConfig : Autocomplete.ViewConfig Location
+viewConfig =
+    let
+        customizedLi keySelected mouseSelected location =
+            { attributes =
+                [ classList [ ( "autocomplete-item", True ), ( "key-selected", keySelected || mouseSelected ) ]
+                , id (toString location.id)
+                ]
+            , children = [ Html.text location.name ]
+            }
+    in
+        Autocomplete.viewConfig
+            { toId = .id >> toString
+            , ul = [ class "autocomplete-list" ]
+            , li = customizedLi
+            }
+
+
+
+-- LOCATIONS
+
+
+parseId : String -> Maybe Int
+parseId =
+    String.toInt >> Result.toMaybe

--- a/app/assets/javascripts/LocationSelector.elm
+++ b/app/assets/javascripts/LocationSelector.elm
@@ -34,9 +34,9 @@ type alias Model =
 
 init : List Location -> Model
 init locations =
-    { locations = locations
+    { locations = List.sortBy .name locations
     , autoState = Autocomplete.empty
-    , howManyToShow = 5
+    , howManyToShow = 8
     , query = ""
     , selectedLocation = Nothing
     , showMenu = False

--- a/app/assets/javascripts/LocationSelector.elm
+++ b/app/assets/javascripts/LocationSelector.elm
@@ -15,7 +15,9 @@ import Utils exposing ((&>))
 
 subscriptions : Sub Msg
 subscriptions =
-    Sub.map SetAutoState Autocomplete.subscription
+    -- TODO: keyboard control is not supported yet :(
+    -- Sub.map SetAutoState Autocomplete.subscription
+    Sub.none
 
 
 type alias Model =
@@ -44,6 +46,7 @@ type Msg
     | SetAutoState Autocomplete.Msg
     | Wrap Bool
     | Reset
+    | OverlayClicked
     | HandleEscape
     | SelectLocationKeyboard Int
     | SelectLocationMouse Int
@@ -55,6 +58,7 @@ type Msg
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
+        -- case msg of
         SetQuery newQuery ->
             let
                 showMenu =
@@ -77,8 +81,11 @@ update msg model =
                     Just updateMsg ->
                         update updateMsg newModel
 
+        OverlayClicked ->
+            escape model ! []
+
         HandleEscape ->
-            close model ! []
+            escape model ! []
 
         Wrap toTop ->
             case model.selectedLocation of
@@ -204,6 +211,7 @@ view model =
                         , id "location-input"
                         , class "autocomplete-input"
                         , autocomplete False
+                        , spellcheck False
                         , attribute "role" "combobox"
                         ]
                         []
@@ -217,7 +225,7 @@ overlay : Model -> Html Msg
 overlay model =
     div
         [ class "autocomplete-overlay"
-        , onClick HandleEscape
+        , onClick OverlayClicked
         , hidden (not model.showMenu)
         , style
             [ ( "backgroundColor", "rgba(0,0,0,0)" )
@@ -240,8 +248,7 @@ acceptableLocations query locations =
         List.filter (String.contains lowerQuery << String.toLower << .name) locations
 
 
-close : Model -> Model
-close model =
+escape model =
     let
         validOptions =
             not <| List.isEmpty (acceptableLocations model.query model.locations)
@@ -265,6 +272,11 @@ close model =
 
             Nothing ->
                 clearModel
+
+
+close : Model -> Model
+close =
+    resetMenu
 
 
 viewMenu : Model -> Html Msg

--- a/app/assets/javascripts/LocationSelector.elm
+++ b/app/assets/javascripts/LocationSelector.elm
@@ -217,7 +217,7 @@ view model =
                 Nothing ->
                     model.query
     in
-        div []
+        div [ class "autocomplete-wrapper" ]
             (List.append
                 [ input
                     [ onInput SetQuery

--- a/app/assets/javascripts/LocationSelector.elm
+++ b/app/assets/javascripts/LocationSelector.elm
@@ -333,7 +333,10 @@ viewConfig =
                 [ classList [ ( "autocomplete-item", True ), ( "key-selected", keySelected || mouseSelected ) ]
                 , id (toString location.id)
                 ]
-            , children = [ Html.text location.name ]
+            , children =
+                [ Html.text location.name
+                , Html.span [ class "autocomplete-item-context" ] [ Html.text (Maybe.withDefault "" location.parentName) ]
+                ]
             }
     in
         Autocomplete.viewConfig

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -23,8 +23,9 @@ type alias Flags =
     , contactEmail : String
     , locale : String
     , locales : List ( String, String )
-    , facilityTypes : List (FacilityType)
-    , ownerships : List (Ownership)
+    , facilityTypes : List FacilityType
+    , ownerships : List Ownership
+    , locations : List Location
     }
 
 
@@ -92,6 +93,7 @@ init flags route =
             , locales = flags.locales
             , facilityTypes = flags.facilityTypes
             , ownerships = flags.ownerships
+            , locations = flags.locations
             }
 
         model =

--- a/app/assets/javascripts/MainMenu.js.elm
+++ b/app/assets/javascripts/MainMenu.js.elm
@@ -30,6 +30,7 @@ init flags =
       , locales = flags.locales
       , facilityTypes = []
       , ownerships = []
+      , locations = []
       }
     , Cmd.none
     )

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -14,6 +14,7 @@ type alias Settings =
     , locales : List ( String, String )
     , facilityTypes : List FacilityType
     , ownerships : List Ownership
+    , locations : List Location
     }
 
 

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -234,3 +234,18 @@ floatParam : String -> Dict String String -> Maybe Float
 floatParam key params =
     Dict.get key params
         &> (String.toFloat >> Result.toMaybe)
+
+
+setQuery : String -> SearchSpec -> SearchSpec
+setQuery q search =
+    { search | q = Just q }
+
+
+setType : Int -> SearchSpec -> SearchSpec
+setType id search =
+    { search | fType = Just id }
+
+
+setOwnership : Int -> SearchSpec -> SearchSpec
+setOwnership id search =
+    { search | ownership = Just id }

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -1,14 +1,19 @@
 module Suggest exposing (Config, Model, Msg(..), PrivateMsg, init, empty, update, hasSuggestionsToShow, viewInput, viewInputWith, viewSuggestions, advancedSearchWindow)
 
-import Shared exposing (icon)
+import AdvancedSearch
 import Api
+import Debounce
 import Html exposing (..)
+import Html.App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
-import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership)
-import String
-import Debounce
 import I18n exposing (..)
+import List
+import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership)
+import Return
+import Shared exposing (icon)
+import String
+import Utils
 
 
 type alias Config =
@@ -16,7 +21,7 @@ type alias Config =
 
 
 type alias Model =
-    { query : String, advancedSearch : SearchSpec, suggestions : Maybe (List Models.Suggestion), d : Debounce.State, advanced : Bool }
+    { query : String, advancedSearch : AdvancedSearch.Model, suggestions : Maybe (List Models.Suggestion), d : Debounce.State, advanced : Bool }
 
 
 type PrivateMsg
@@ -24,10 +29,7 @@ type PrivateMsg
     | ApiSug Api.SuggestionsMsg
     | FetchSuggestions
     | Deb (Debounce.Msg Msg)
-    | ToggleAdvancedSearch
-    | SetAdvancedSearchName String
-    | SetAdvancedSearchType Int
-    | SetAdvancedSearchOwnership Int
+    | AdvancedSearchMsg AdvancedSearch.Msg
 
 
 type Msg
@@ -35,8 +37,8 @@ type Msg
     | ServiceClicked Int
     | LocationClicked Int
     | Search String
-    | Private PrivateMsg
     | FullSearch SearchSpec
+    | Private PrivateMsg
 
 
 hasSuggestionsToShow : Model -> Bool
@@ -51,7 +53,7 @@ empty =
 
 init : String -> Model
 init query =
-    { query = query, advancedSearch = Models.emptySearch, suggestions = Nothing, d = Debounce.init, advanced = False }
+    { query = query, advancedSearch = AdvancedSearch.init, suggestions = Nothing, d = Debounce.init, advanced = False }
 
 
 searchSuggestions : Config -> Model -> ( Model, Cmd Msg )
@@ -89,32 +91,17 @@ update config msg model =
                 Deb a ->
                     Debounce.update cfg a model
 
-                ToggleAdvancedSearch ->
-                    if not (isAdvancedSearchOpen model) then
-                        ( { model | advanced = True }, Cmd.none )
-                    else
-                        ( { model | advanced = False }, Cmd.none )
+                AdvancedSearchMsg msg ->
+                    case msg of
+                        AdvancedSearch.Toggle ->
+                            ( { model | advanced = not model.advanced }, Cmd.none )
 
-                SetAdvancedSearchName search ->
-                    let
-                        currentSearch =
-                            model.advancedSearch
-                    in
-                        ( { model | advancedSearch = { currentSearch | q = Just search } }, Cmd.none )
+                        AdvancedSearch.Perform search ->
+                            ( model, Utils.performMessage (FullSearch search) )
 
-                SetAdvancedSearchType t ->
-                    let
-                        currentSearch =
-                            model.advancedSearch
-                    in
-                        ( { model | advancedSearch = { currentSearch | fType = Just t } }, Cmd.none )
-
-                SetAdvancedSearchOwnership o ->
-                    let
-                        currentSearch =
-                            model.advancedSearch
-                    in
-                        ( { model | advancedSearch = { currentSearch | ownership = Just o } }, Cmd.none )
+                        _ ->
+                            AdvancedSearch.update model.advancedSearch msg
+                                |> Return.mapBoth (Private << AdvancedSearchMsg) (setAdvancedSearch model)
 
         _ ->
             -- public events
@@ -209,51 +196,22 @@ suggestion s =
 advancedSearchFooter =
     div
         [ class "footer" ]
-        [ a [ href "#", Shared.onClick (Private ToggleAdvancedSearch) ] [ text "Advanced Search" ] ]
+        [ a [ href "#", Shared.onClick (Private (AdvancedSearchMsg AdvancedSearch.Toggle)) ] [ text "Advanced Search" ] ]
+
+
+advancedSearchWindow : Model -> List FacilityType -> List Ownership -> List (Html Msg)
+advancedSearchWindow model types ownership =
+    if model.advanced then
+        List.map (Html.App.map (Private << AdvancedSearchMsg)) (AdvancedSearch.view model.advancedSearch types ownership)
+    else
+        []
+
+
+setAdvancedSearch : Model -> AdvancedSearch.Model -> Model
+setAdvancedSearch model advancedSearch =
+    { model | advancedSearch = advancedSearch }
 
 
 isAdvancedSearchOpen : Model -> Bool
 isAdvancedSearchOpen model =
     model.advanced
-
-
-advancedSearchWindow : Model -> List FacilityType -> List Ownership -> List (Html Msg)
-advancedSearchWindow model types ownerships =
-    let
-        query =
-            Maybe.withDefault "" model.advancedSearch.q
-    in
-        if isAdvancedSearchOpen model then
-            Shared.modalWindow
-                [ text "Advanced Search"
-                , a [ href "#", class "right", Shared.onClick (Private ToggleAdvancedSearch) ] [ Shared.icon "close" ]
-                ]
-                [ Html.form [ action "#", method "GET" ]
-                    [ label [ for "q" ] [ text "Facility name" ]
-                    , input [ id "q", type' "text", value query, onInput (Private << SetAdvancedSearchName) ] []
-                    , label [] [ text "Facility type" ]
-                    , Html.select [ Shared.onSelect (Private << SetAdvancedSearchType) ] (selectOptions types model.advancedSearch.fType)
-                    , label [] [ text "Ownership" ]
-                    , Html.select [ Shared.onSelect (Private << SetAdvancedSearchOwnership) ] (selectOptions ownerships model.advancedSearch.ownership)
-                    ]
-                ]
-                [ a [ href "#", class "btn-flat", Shared.onClick (FullSearch model.advancedSearch) ] [ text "Search" ] ]
-        else
-            []
-
-
-selectOptions : List { id : Int, name : String } -> Maybe Int -> List (Html a)
-selectOptions options choice =
-    let
-        selectedId =
-            Maybe.withDefault 0 choice
-    in
-        [ Html.option [ value "0" ] [ text "" ] ]
-            ++ (List.map
-                    (\option ->
-                        Html.option
-                            [ value (toString option.id), selected (option.id == selectedId) ]
-                            [ text option.name ]
-                    )
-                    options
-               )

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -54,7 +54,7 @@ empty settings =
 init : Models.Settings -> String -> Model
 init settings query =
     { query = query
-    , advancedSearch = AdvancedSearch.init settings.facilityTypes settings.ownerships
+    , advancedSearch = AdvancedSearch.init settings.facilityTypes settings.ownerships settings.locations
     , suggestions = Nothing
     , d = Debounce.init
     , advanced = False

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -1,4 +1,4 @@
-module Suggest exposing (Config, Model, Msg(..), PrivateMsg, init, empty, update, hasSuggestionsToShow, viewInput, viewInputWith, viewSuggestions, advancedSearchWindow)
+module Suggest exposing (Config, Model, Msg(..), PrivateMsg, init, empty, update, subscriptions, hasSuggestionsToShow, viewInput, viewInputWith, viewSuggestions, advancedSearchWindow)
 
 import AdvancedSearch
 import Api
@@ -115,6 +115,11 @@ cfg =
 
 debCmd =
     Debounce.debounceCmd cfg
+
+
+subscriptions : Sub Msg
+subscriptions =
+    Sub.map (Private << AdvancedSearchMsg) AdvancedSearch.subscriptions
 
 
 viewInput : Model -> Html Msg

--- a/app/assets/stylesheets/_autocomplete.scss
+++ b/app/assets/stylesheets/_autocomplete.scss
@@ -1,0 +1,78 @@
+.autocomplete-wrapper {
+  position: relative;
+}
+
+.autocomplete-menu {
+    position: absolute;
+    width: 100%;
+    margin-top: -15px;
+    background: white;
+    color: black;
+    border: 1px solid #DDD;
+    border-radius: 3px;
+    box-shadow: 0 0 5px rgba(0,0,0,0.1);
+}
+
+.autocomplete-item {
+    display: block;
+    padding: 5px 10px;
+    border-bottom: 1px solid #DDD;
+    cursor: pointer;
+}
+
+.key-selected {
+    background-color: $blue;
+    color: white;
+}
+
+.mouse-selected {
+    background-color: #ececec;
+}
+
+.autocomplete-list {
+    list-style: none;
+    padding: 0;
+    margin: auto;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.autocomplete-list-with-sections {
+  ist-style: none;
+  padding: 0;
+  margin: auto;
+}
+
+.autocomplete-input {
+    min-width: 120px;
+    color: black;
+    font-size: 12px;
+    padding: 4px;
+    border-radius: 4px;
+    background-color: white;
+}
+
+.autocomplete-section-list {
+  list-style: none;
+  padding: 0;
+  margin: auto;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.autocomplete-section-item {
+  display: block;
+  padding: 0;
+}
+
+.autocomplete-section-box {
+  display: block;
+  padding: 0;
+  border-top: 1px solid #888888;
+  border-bottom: 1px solid #888888;
+}
+
+.autocomplete-section-text {
+  display: flex;
+  justify-content: center;
+}

--- a/app/assets/stylesheets/_autocomplete.scss
+++ b/app/assets/stylesheets/_autocomplete.scss
@@ -27,12 +27,7 @@
   }
 
   &.key-selected {
-    background-color: $blue;
-    color: white;
-
-    .autocomplete-item-context {
-      color: white;
-    }
+    background-color: #DDD;
   }
 }
 

--- a/app/assets/stylesheets/_autocomplete.scss
+++ b/app/assets/stylesheets/_autocomplete.scss
@@ -3,50 +3,50 @@
 }
 
 .autocomplete-menu {
-    position: absolute;
-    width: 100%;
-    margin-top: -15px;
-    background: white;
-    color: black;
-    border: 1px solid #DDD;
-    border-radius: 3px;
-    box-shadow: 0 0 5px rgba(0,0,0,0.1);
+  position: absolute;
+  width: 100%;
+  margin-top: -15px;
+  background: white;
+  color: black;
+  border: 1px solid #DDD;
+  border-radius: 3px;
+  box-shadow: 0 0 5px rgba(0,0,0,0.1);
 }
 
 .autocomplete-item {
-    display: block;
-    padding: 5px 10px;
-    border-bottom: 1px solid #DDD;
-    cursor: pointer;
+  display: block;
+  padding: 5px 10px;
+  border-bottom: 1px solid #DDD;
+  cursor: pointer;
+
+  .autocomplete-item-context {
+    float: right;
+    font-size: 13px;
+    color: $color_mountain_mist_approx;
+    margin-top: 1px;
+  }
+
+  &.key-selected {
+    background-color: $blue;
+    color: white;
 
     .autocomplete-item-context {
-        float: right;
-        font-size: 13px;
-        color: $color_mountain_mist_approx;
-        margin-top: 1px;
-    }
-
-    &.key-selected {
-      background-color: $blue;
       color: white;
-
-      .autocomplete-item-context {
-            color: white;
-      }
     }
+  }
 }
 
 
 .mouse-selected {
-    background-color: #ececec;
+  background-color: #ececec;
 }
 
 .autocomplete-list {
-    list-style: none;
-    padding: 0;
-    margin: auto;
-    max-height: 200px;
-    overflow-y: auto;
+  list-style: none;
+  padding: 0;
+  margin: auto;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .autocomplete-list-with-sections {
@@ -56,12 +56,12 @@
 }
 
 .autocomplete-input {
-    min-width: 120px;
-    color: black;
-    font-size: 12px;
-    padding: 4px;
-    border-radius: 4px;
-    background-color: white;
+  min-width: 120px;
+  color: black;
+  font-size: 12px;
+  padding: 4px;
+  border-radius: 4px;
+  background-color: white;
 }
 
 .autocomplete-section-list {

--- a/app/assets/stylesheets/_autocomplete.scss
+++ b/app/assets/stylesheets/_autocomplete.scss
@@ -18,12 +18,24 @@
     padding: 5px 10px;
     border-bottom: 1px solid #DDD;
     cursor: pointer;
+
+    .autocomplete-item-context {
+        float: right;
+        font-size: 13px;
+        color: $color_mountain_mist_approx;
+        margin-top: 1px;
+    }
+
+    &.key-selected {
+      background-color: $blue;
+      color: white;
+
+      .autocomplete-item-context {
+            color: white;
+      }
+    }
 }
 
-.key-selected {
-    background-color: $blue;
-    color: white;
-}
 
 .mouse-selected {
     background-color: #ececec;

--- a/app/assets/stylesheets/_modal.scss
+++ b/app/assets/stylesheets/_modal.scss
@@ -8,6 +8,7 @@
   margin: 0 auto;
   max-height: 80%;
   width: 400px;
+  overflow-y: visible;
 
   select {
     display: block;
@@ -30,9 +31,13 @@
     }
 
     .body {
-      padding: 24px;
+      padding: 24px 24px 0 24px;
       label {
         color: $color_mountain_mist_approx;
+      }
+
+      form .field {
+        margin-bottom: 10px;
       }
     }
   }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -6,6 +6,7 @@
 @import 'facility_details';
 @import 'modal';
 @import 'notice';
+@import 'autocomplete';
 
 
 html, body, #container, #elm, #map {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,9 @@ class ApplicationController < ActionController::Base
       "locales" => Settings.locales,
       "locale" => I18n.locale,
       "facilityTypes" => ElasticsearchService.instance.get_facility_types,
-      "ownerships" => ElasticsearchService.instance.get_ownerships
+      "ownerships" => ElasticsearchService.instance.get_ownerships,
+      # TODO
+      "locations" => ElasticsearchService.instance.get_locations.map { |l| l["parentName"] = l["parent_name"]; l }
     }
   end
 end

--- a/app/models/elasticsearch_service.rb
+++ b/app/models/elasticsearch_service.rb
@@ -148,6 +148,12 @@ class ElasticsearchService
     result["hits"]["hits"].map { |h| h["_source"] }
   end
 
+  def get_locations
+    # TODO: do not fetch all locations together
+    result = client.search({index: @index_name, type: 'location', body: { size: 1000, sort: { id: { order: "asc" } } }})
+    result["hits"]["hits"].map { |h| h["_source"] }
+  end
+
   def get_facility(id)
     result = client.search({
       index: @index_name,

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,11 +13,13 @@
         "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",
         "bcardiff/elm-debounce": "1.1.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
+        "elm-lang/dom": "1.1.0 <= v < 2.0.0",
         "elm-lang/geolocation": "1.0.0 <= v < 2.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
         "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
         "evancz/elm-http": "3.0.1 <= v < 4.0.0",
-        "evancz/url-parser": "1.0.0 <= v < 2.0.0"
+        "evancz/url-parser": "1.0.0 <= v < 2.0.0",
+        "thebritican/elm-autocomplete": "4.0.2 <= v < 5.0.0"
     },
     "elm-version": "0.17.1 <= v < 0.18.0"
 }


### PR DESCRIPTION
Added an autocomplete selector for locations in advanced search window.

This included a refactor to separate all advanced search logic in a separate module. This should make #75 easier to implement, since we need to decouple that functionality from the Suggest module.

The UI looks like this:
<img width="1266" alt="screen shot 2016-11-06 at 9 13 41 pm" src="https://cloud.githubusercontent.com/assets/753421/20043123/00b2ffb4-a466-11e6-8d67-61f820d8aa91.png">


Caveats:
- Keyboard support is disabled, we'll need some more time to make that work.
- Locations are currently rendered in the applications html along facility types and ownership kinds. This isn't ideal, because it's a very big list and we would be sending it to every user even if they don't use advanced search. I'll open a separate ticket to work on lazily loading and caching this information.