### PR TITLE
Advanced search access

### DIFF
--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -51,7 +51,7 @@ init facilityTypes ownerships locations search =
     , q = search.q
     , fType = search.fType
     , ownership = search.ownership
-    , selector = LocationSelector.init locations
+    , selector = LocationSelector.init locations search.location
     }
 
 

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -19,7 +19,7 @@ import Selector
 import Models exposing (SearchSpec, Service, FacilityType, Ownership, Location, emptySearch)
 import Return exposing (Return)
 import Shared exposing (onClick)
-import Utils
+import Utils exposing (perform)
 
 
 type alias Model =
@@ -128,7 +128,7 @@ update model msg =
 
                 FetchFailed ->
                     Return.singleton model
-                        |> Return.command (Utils.performMessage UnhandledError)
+                        |> perform UnhandledError
 
         _ ->
             -- Public events

--- a/app/assets/javascripts/AdvancedSearch.elm
+++ b/app/assets/javascripts/AdvancedSearch.elm
@@ -6,6 +6,7 @@ module AdvancedSearch
         , update
         , subscriptions
         , view
+        , isEmpty
         )
 
 import Html exposing (..)
@@ -43,13 +44,13 @@ type PrivateMsg
     | HideSelector
 
 
-init : List FacilityType -> List Ownership -> List Location -> Model
-init facilityTypes ownerships locations =
+init : List FacilityType -> List Ownership -> List Location -> SearchSpec -> Model
+init facilityTypes ownerships locations search =
     { facilityTypes = facilityTypes
     , ownerships = ownerships
-    , q = Nothing
-    , fType = Nothing
-    , ownership = Nothing
+    , q = search.q
+    , fType = search.fType
+    , ownership = search.ownership
     , selector = LocationSelector.init locations
     }
 
@@ -158,3 +159,8 @@ selectOptions options choice =
                     )
                     options
                )
+
+
+isEmpty : Model -> Bool
+isEmpty model =
+    Models.isEmpty (search model)

--- a/app/assets/javascripts/Api.elm
+++ b/app/assets/javascripts/Api.elm
@@ -1,4 +1,17 @@
-module Api exposing (SuggestionsMsg(..), getSuggestions, FetchFacilityMsg(..), fetchFacility, SearchMsg(..), search, searchMore)
+module Api
+    exposing
+        ( SuggestionsMsg(..)
+        , getSuggestions
+        , FetchFacilityMsg(..)
+        , fetchFacility
+        , ServicesMsg(..)
+        , getServices
+        , LocationsMsg(..)
+        , getLocations
+        , SearchMsg(..)
+        , search
+        , searchMore
+        )
 
 import Decoders exposing (..)
 import Http
@@ -33,6 +46,26 @@ fetchFacility wmsg id =
             "/api/facilities/" ++ (toString id)
     in
         Task.perform (wmsg << FetchFacilityFailed) (wmsg << FetchFacilitySuccess) (Http.get Decoders.facility url)
+
+
+type LocationsMsg
+    = LocationsSuccess (List Location)
+    | LocationsFailed Http.Error
+
+
+getLocations : (Http.Error -> msg) -> (List Location -> msg) -> Cmd msg
+getLocations error ok =
+    Task.perform error ok (Http.get Decoders.locations "/api/locations")
+
+
+type ServicesMsg
+    = ServicesSuccess (List Service)
+    | ServicesFailed Http.Error
+
+
+getServices : (Http.Error -> msg) -> (List Service -> msg) -> Cmd msg
+getServices error ok =
+    Task.perform error ok (Http.get Decoders.services "/api/services")
 
 
 type SearchMsg

--- a/app/assets/javascripts/AppFacilityDetails.elm
+++ b/app/assets/javascripts/AppFacilityDetails.elm
@@ -8,7 +8,7 @@ import Html.Events as Events
 import Shared exposing (MapView, classNames)
 import Api
 import Date exposing (Date)
-import Utils
+import Utils exposing (perform)
 import Time
 import String
 import Task
@@ -49,8 +49,9 @@ type alias FacilityReport =
     , closed : Bool
     , contact_info_missing : Bool
     , inaccurate_services : Bool
-    , other : Bool
-    --, comments : Maybe String
+    , other :
+        Bool
+        --, comments : Maybe String
     }
 
 
@@ -82,7 +83,8 @@ update s msg model =
                           )
 
                 ApiFetch (Api.FetchFacilityFailed _) ->
-                    ( model, Utils.performMessage UnhandledError )
+                    Return.singleton model
+                        |> perform UnhandledError
 
                 UserLocationMsg msg ->
                     UserLocation.update s msg (userLocation model)

--- a/app/assets/javascripts/AppHome.elm
+++ b/app/assets/javascripts/AppHome.elm
@@ -5,7 +5,7 @@ import Html.App
 import Map
 import Models exposing (Settings, MapViewport, LatLng, SearchResult, FacilityType, Ownership, SearchSpec, shouldLoadMore, emptySearch)
 import Shared exposing (MapView)
-import Utils
+import Utils exposing (perform)
 import UserLocation
 import Suggest
 import Debounce
@@ -67,19 +67,24 @@ update s msg model =
                 SuggestMsg msg ->
                     case msg of
                         Suggest.FacilityClicked facilityId ->
-                            ( model, Utils.performMessage (FacilityClicked facilityId) )
+                            Return.singleton model
+                                |> perform (FacilityClicked facilityId)
 
                         Suggest.ServiceClicked serviceId ->
-                            ( model, Utils.performMessage (ServiceClicked serviceId) )
+                            Return.singleton model
+                                |> perform (ServiceClicked serviceId)
 
                         Suggest.LocationClicked locationId ->
-                            ( model, Utils.performMessage (LocationClicked locationId) )
+                            Return.singleton model
+                                |> perform (LocationClicked locationId)
 
                         Suggest.Search search ->
-                            ( model, Utils.performMessage (Search search) )
+                            Return.singleton model
+                                |> perform (Search search)
 
                         Suggest.UnhandledError ->
-                            ( model, Utils.performMessage UnhandledError )
+                            Return.singleton model
+                                |> perform UnhandledError
 
                         _ ->
                             Suggest.update { mapViewport = model.mapViewport } msg model.suggest
@@ -102,7 +107,8 @@ update s msg model =
                         model ! [ loadMore, addFacilities ]
 
                 ApiSearch _ (Api.SearchFailed _) ->
-                    ( model, Utils.performMessage UnhandledError )
+                    Return.singleton model
+                        |> perform UnhandledError
 
                 MapMsg (Map.MapViewportChanged mapViewport) ->
                     ( { model | mapViewport = mapViewport }, debCmd (Private PerformSearch) )

--- a/app/assets/javascripts/AppHome.elm
+++ b/app/assets/javascripts/AppHome.elm
@@ -33,10 +33,9 @@ type Msg
     = FacilityClicked Int
     | ServiceClicked Int
     | LocationClicked Int
-    | Search String
     | Private PrivateMsg
     | UnhandledError
-    | FullSearch SearchSpec
+    | Search SearchSpec
 
 
 init : Settings -> MapViewport -> UserLocation.Model -> ( Model, Cmd Msg )
@@ -76,11 +75,8 @@ update s msg model =
                         Suggest.LocationClicked locationId ->
                             ( model, Utils.performMessage (LocationClicked locationId) )
 
-                        Suggest.Search q ->
-                            ( model, Utils.performMessage (Search q) )
-
-                        Suggest.FullSearch search ->
-                            ( model, Utils.performMessage (FullSearch search) )
+                        Suggest.Search search ->
+                            ( model, Utils.performMessage (Search search) )
 
                         Suggest.UnhandledError ->
                             ( model, Utils.performMessage UnhandledError )

--- a/app/assets/javascripts/AppHome.elm
+++ b/app/assets/javascripts/AppHome.elm
@@ -42,8 +42,11 @@ type Msg
 init : Settings -> MapViewport -> UserLocation.Model -> ( Model, Cmd Msg )
 init settings mapViewport userLocation =
     let
+        ( suggestModel, suggestCmd ) =
+            Suggest.empty settings
+
         model =
-            { suggest = Suggest.empty settings
+            { suggest = suggestModel
             , mapViewport = mapViewport
             , userLocation = userLocation
             , d = Debounce.init
@@ -53,6 +56,7 @@ init settings mapViewport userLocation =
             ! [ searchAllFacilitiesStartingFrom mapViewport.center
               , Map.removeHighlightedFacilityMarker
               , Map.fitContentUsingPadding False
+              , Cmd.map (Private << SuggestMsg) suggestCmd
               ]
 
 
@@ -77,6 +81,9 @@ update s msg model =
 
                         Suggest.FullSearch search ->
                             ( model, Utils.performMessage (FullSearch search) )
+
+                        Suggest.UnhandledError ->
+                            ( model, Utils.performMessage UnhandledError )
 
                         _ ->
                             Suggest.update { mapViewport = model.mapViewport } msg model.suggest

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -57,7 +57,7 @@ init : Settings -> SearchSpec -> MapViewport -> UserLocation.Model -> ( Model, C
 init s query mapViewport userLocation =
     let
         model =
-            { suggest = Suggest.init s (queryText query)
+            { suggest = Suggest.init s query
             , query = query
             , mapViewport = mapViewport
             , userLocation = userLocation
@@ -294,11 +294,6 @@ mapViewport model =
 userLocation : Model -> UserLocation.Model
 userLocation model =
     model.userLocation
-
-
-queryText : SearchSpec -> String
-queryText searchSpec =
-    Maybe.withDefault "" searchSpec.q
 
 
 searchResults : Model -> Html Msg

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -56,8 +56,11 @@ restoreCmd =
 init : Settings -> SearchSpec -> MapViewport -> UserLocation.Model -> ( Model, Cmd Msg )
 init s query mapViewport userLocation =
     let
+        ( suggestModel, suggestCmd ) =
+            Suggest.init s query
+
         model =
-            { suggest = Suggest.init s query
+            { suggest = suggestModel
             , query = query
             , mapViewport = mapViewport
             , userLocation = userLocation
@@ -69,6 +72,7 @@ init s query mapViewport userLocation =
         model
             ! [ Api.search (Private << ApiSearch) { query | latLng = Just mapViewport.center }
               , restoreCmd
+              , Cmd.map (Private << SuggestMsg) suggestCmd
               ]
 
 
@@ -147,6 +151,9 @@ update s msg model =
 
                         Suggest.FullSearch search ->
                             ( model, Utils.performMessage (Search <| search) )
+
+                        Suggest.UnhandledError ->
+                            ( model, Utils.performMessage UnhandledError )
 
                         _ ->
                             Suggest.update { mapViewport = model.mapViewport } msg model.suggest

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -8,7 +8,7 @@ import Html.Attributes exposing (..)
 import Html.Events as Events
 import Models exposing (Settings, MapViewport, SearchSpec, SearchResult, Facility, LatLng, FacilitySummary, FacilityType, Ownership, shouldLoadMore, emptySearch)
 import Shared exposing (MapView, icon, classNames)
-import Utils
+import Utils exposing (perform)
 import UserLocation
 import Suggest
 import Debounce
@@ -112,7 +112,8 @@ update s msg model =
                             ! [ loadMore, Map.fitContent, addFacilities ]
 
                 ApiSearch (Api.SearchFailed _) ->
-                    ( model, Utils.performMessage UnhandledError )
+                    Return.singleton model
+                        |> perform UnhandledError
 
                 ApiSearchMore (Api.SearchSuccess results) ->
                     let
@@ -129,7 +130,8 @@ update s msg model =
                         model ! [ loadMore, addFacilities ]
 
                 ApiSearchMore _ ->
-                    ( model, Utils.performMessage UnhandledError )
+                    Return.singleton model
+                        |> perform UnhandledError
 
                 UserLocationMsg msg ->
                     UserLocation.update s msg model.userLocation
@@ -138,19 +140,24 @@ update s msg model =
                 SuggestMsg msg ->
                     case msg of
                         Suggest.FacilityClicked facilityId ->
-                            ( model, Utils.performMessage (FacilityClicked facilityId) )
+                            Return.singleton model
+                                |> perform (FacilityClicked facilityId)
 
                         Suggest.ServiceClicked serviceId ->
-                            ( model, Utils.performMessage (ServiceClicked serviceId) )
+                            Return.singleton model
+                                |> perform (ServiceClicked serviceId)
 
                         Suggest.LocationClicked locationId ->
-                            ( model, Utils.performMessage (LocationClicked locationId) )
+                            Return.singleton model
+                                |> perform (LocationClicked locationId)
 
                         Suggest.Search search ->
-                            ( model, Utils.performMessage (Search <| search) )
+                            Return.singleton model
+                                |> perform (Search <| search)
 
                         Suggest.UnhandledError ->
-                            ( model, Utils.performMessage UnhandledError )
+                            Return.singleton model
+                                |> perform UnhandledError
 
                         _ ->
                             Suggest.update { mapViewport = model.mapViewport } msg model.suggest

--- a/app/assets/javascripts/AppSearch.elm
+++ b/app/assets/javascripts/AppSearch.elm
@@ -146,10 +146,7 @@ update s msg model =
                         Suggest.LocationClicked locationId ->
                             ( model, Utils.performMessage (LocationClicked locationId) )
 
-                        Suggest.Search q ->
-                            ( model, Utils.performMessage (Search <| { emptySearch | q = Just q }) )
-
-                        Suggest.FullSearch search ->
+                        Suggest.Search search ->
                             ( model, Utils.performMessage (Search <| search) )
 
                         Suggest.UnhandledError ->

--- a/app/assets/javascripts/Decoders.elm
+++ b/app/assets/javascripts/Decoders.elm
@@ -58,12 +58,22 @@ service =
         |> required "facility_count" int
 
 
+services : Decoder (List Service)
+services =
+    list service
+
+
 location : Decoder Location
 location =
     decode Location
         |> required "id" int
         |> required "name" string
         |> optional "parent_name" (nullable string) Nothing
+
+
+locations : Decoder (List Location)
+locations =
+    list location
 
 
 latLng : Decoder LatLng

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -25,8 +25,6 @@ type alias Flags =
     , locales : List ( String, String )
     , facilityTypes : List FacilityType
     , ownerships : List Ownership
-    , locations : List Location
-    , services : List Service
     }
 
 
@@ -94,8 +92,6 @@ init flags route =
             , locales = flags.locales
             , facilityTypes = flags.facilityTypes
             , ownerships = flags.ownerships
-            , locations = flags.locations
-            , services = flags.services
             }
 
         model =

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -176,11 +176,8 @@ mainUpdate msg mainModel =
                                 AppHome.LocationClicked locationId ->
                                     ( homeModel, navigateSearchLocation locationId )
 
-                                AppHome.FullSearch search ->
+                                AppHome.Search search ->
                                     ( homeModel, navigateSearch search )
-
-                                AppHome.Search q ->
-                                    ( homeModel, navigateSearchQuery q )
 
                                 AppHome.Private _ ->
                                     mapCmd HomeMsg <| AppHome.update common.settings msg homeModel
@@ -485,11 +482,6 @@ navigateSearchService id =
 navigateSearchLocation : Int -> Cmd MainMsg
 navigateSearchLocation id =
     Utils.performMessage <| Navigate (SearchRoute { emptySearch | location = Just id })
-
-
-navigateSearchQuery : String -> Cmd MainMsg
-navigateSearchQuery q =
-    Utils.performMessage <| Navigate (SearchRoute { emptySearch | q = Just q })
 
 
 navigateSearch : SearchSpec -> Cmd MainMsg

--- a/app/assets/javascripts/Main.js.elm
+++ b/app/assets/javascripts/Main.js.elm
@@ -26,6 +26,7 @@ type alias Flags =
     , facilityTypes : List FacilityType
     , ownerships : List Ownership
     , locations : List Location
+    , services : List Service
     }
 
 
@@ -94,6 +95,7 @@ init flags route =
             , facilityTypes = flags.facilityTypes
             , ownerships = flags.ownerships
             , locations = flags.locations
+            , services = flags.services
             }
 
         model =

--- a/app/assets/javascripts/MainMenu.js.elm
+++ b/app/assets/javascripts/MainMenu.js.elm
@@ -30,8 +30,6 @@ init flags =
       , locales = flags.locales
       , facilityTypes = []
       , ownerships = []
-      , locations = []
-      , services = []
       }
     , Cmd.none
     )

--- a/app/assets/javascripts/MainMenu.js.elm
+++ b/app/assets/javascripts/MainMenu.js.elm
@@ -31,6 +31,7 @@ init flags =
       , facilityTypes = []
       , ownerships = []
       , locations = []
+      , services = []
       }
     , Cmd.none
     )

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -15,6 +15,7 @@ type alias Settings =
     , facilityTypes : List FacilityType
     , ownerships : List Ownership
     , locations : List Location
+    , services : List Service
     }
 
 

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -209,6 +209,23 @@ emptySearch =
     { q = Nothing, service = Nothing, location = Nothing, latLng = Nothing, fType = Nothing, ownership = Nothing }
 
 
+searchEquals : SearchSpec -> SearchSpec -> Bool
+searchEquals s1 s2 =
+    List.all identity
+        [ Utils.equalMaybe (Maybe.andThen s1.q discardEmpty) (Maybe.andThen s2.q discardEmpty)
+        , Utils.equalMaybe s1.service s2.service
+        , Utils.equalMaybe s1.location s2.location
+        , Utils.equalMaybe s1.latLng s2.latLng
+        , Utils.equalMaybe s1.fType s2.fType
+        , Utils.equalMaybe s1.ownership s2.ownership
+        ]
+
+
+isEmpty : SearchSpec -> Bool
+isEmpty =
+    searchEquals emptySearch
+
+
 
 -- Private
 

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -208,6 +208,11 @@ emptySearch =
     { q = Nothing, service = Nothing, location = Nothing, latLng = Nothing, fType = Nothing, ownership = Nothing }
 
 
+querySearch : String -> SearchSpec
+querySearch q =
+    { emptySearch | q = Just q }
+
+
 searchEquals : SearchSpec -> SearchSpec -> Bool
 searchEquals s1 s2 =
     List.all identity

--- a/app/assets/javascripts/Models.elm
+++ b/app/assets/javascripts/Models.elm
@@ -14,8 +14,6 @@ type alias Settings =
     , locales : List ( String, String )
     , facilityTypes : List FacilityType
     , ownerships : List Ownership
-    , locations : List Location
-    , services : List Service
     }
 
 

--- a/app/assets/javascripts/Selector.elm
+++ b/app/assets/javascripts/Selector.elm
@@ -1,4 +1,4 @@
-module LocationSelector
+module Selector
     exposing
         ( Model
         , Msg
@@ -16,31 +16,46 @@ import Html.App as Html
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Decode as Json
-import Models exposing (Location)
 import String
 import Task
 import Utils exposing ((&>))
 
 
-type alias Model =
-    { locations : List Location
+type alias Model a =
+    { inputId : String
+    , options : List (Option a)
     , autoState : Autocomplete.State
     , howManyToShow : Int
     , query : String
-    , selectedLocation : Maybe Location
+    , selection : Maybe (Option a)
     , showMenu : Bool
     }
 
 
-init : List Location -> Maybe Int -> Model
-init locations selectedId =
-    { locations = List.sortBy .name locations
-    , autoState = Autocomplete.empty
-    , howManyToShow = 8
-    , query = ""
-    , selectedLocation = selectedId &> findById locations
-    , showMenu = False
-    }
+type alias Option a =
+    { id : Int, label : String, item : a }
+
+
+type alias OptionView a =
+    a -> List (Html Never)
+
+
+init : String -> List a -> (a -> Int) -> (a -> String) -> Maybe Int -> Model a
+init id items fId fLabel selectedId =
+    let
+        options =
+            items
+                |> List.map (\a -> { id = fId a, label = fLabel a, item = a })
+                |> List.sortBy .label
+    in
+        { inputId = id
+        , options = options
+        , autoState = Autocomplete.empty
+        , howManyToShow = 8
+        , query = ""
+        , selection = selectedId &> findById options
+        , showMenu = False
+        }
 
 
 type Msg
@@ -50,9 +65,9 @@ type Msg
     | Reset
     | OverlayClicked
     | HandleEscape
-    | SelectLocationKeyboard Int
-    | SelectLocationMouse Int
-    | PreviewLocation Int
+    | SelectKeyboard Int
+    | SelectMouse Int
+    | Preview Int
     | OnFocus
     | NoOp
 
@@ -64,21 +79,20 @@ subscriptions =
     Sub.none
 
 
-update : Msg -> Model -> ( Model, Cmd Msg )
+update : Msg -> Model a -> ( Model a, Cmd Msg )
 update msg model =
     case msg of
-        -- case msg of
         SetQuery newQuery ->
             let
                 showMenu =
-                    not << List.isEmpty <| (acceptableLocations newQuery model.locations)
+                    not << List.isEmpty <| (matches newQuery model.options)
             in
-                { model | query = newQuery, showMenu = showMenu, selectedLocation = Nothing } ! []
+                { model | query = newQuery, showMenu = showMenu, selection = Nothing } ! []
 
         SetAutoState autoMsg ->
             let
                 ( newState, maybeMsg ) =
-                    Autocomplete.update updateConfig autoMsg model.howManyToShow model.autoState (acceptableLocations model.query model.locations)
+                    Autocomplete.update updateConfig autoMsg model.howManyToShow model.autoState (currentMatches model)
 
                 newModel =
                     { model | autoState = newState }
@@ -97,28 +111,28 @@ update msg model =
             escape model ! []
 
         Wrap toTop ->
-            case model.selectedLocation of
-                Just location ->
+            case model.selection of
+                Just _ ->
                     update Reset model
 
                 Nothing ->
                     if toTop then
                         { model
-                            | autoState = Autocomplete.resetToLastItem updateConfig (acceptableLocations model.query model.locations) model.howManyToShow model.autoState
-                            , selectedLocation = List.head <| List.reverse <| List.take model.howManyToShow <| (acceptableLocations model.query model.locations)
+                            | autoState = Autocomplete.resetToLastItem updateConfig (currentMatches model) model.howManyToShow model.autoState
+                            , selection = List.head <| List.reverse <| List.take model.howManyToShow <| (currentMatches model)
                         }
                             ! []
                     else
                         { model
-                            | autoState = Autocomplete.resetToFirstItem updateConfig (acceptableLocations model.query model.locations) model.howManyToShow model.autoState
-                            , selectedLocation = List.head <| List.take model.howManyToShow <| (acceptableLocations model.query model.locations)
+                            | autoState = Autocomplete.resetToFirstItem updateConfig (currentMatches model) model.howManyToShow model.autoState
+                            , selection = List.head <| List.take model.howManyToShow <| (currentMatches model)
                         }
                             ! []
 
         Reset ->
-            { model | autoState = Autocomplete.reset updateConfig model.autoState, selectedLocation = Nothing } ! []
+            { model | autoState = Autocomplete.reset updateConfig model.autoState, selection = Nothing } ! []
 
-        SelectLocationKeyboard id ->
+        SelectKeyboard id ->
             let
                 newModel =
                     setQuery model id
@@ -126,16 +140,16 @@ update msg model =
             in
                 newModel ! []
 
-        SelectLocationMouse id ->
+        SelectMouse id ->
             let
                 newModel =
                     setQuery model id
                         |> close
             in
-                ( newModel, Task.perform (\err -> NoOp) (\_ -> NoOp) (Dom.focus "location-input") )
+                ( newModel, Task.perform (\err -> NoOp) (\_ -> NoOp) (Dom.focus model.inputId) )
 
-        PreviewLocation id ->
-            { model | selectedLocation = Just <| findByIdWithDefault model.locations id } ! []
+        Preview id ->
+            { model | selection = findById model.options id } ! []
 
         OnFocus ->
             model ! []
@@ -151,24 +165,18 @@ resetInput model =
 
 
 removeSelection model =
-    { model | selectedLocation = Nothing }
+    { model | selection = Nothing }
 
 
-findById locations id =
-    List.filter (\location -> location.id == id) locations
+findById options id =
+    List.filter (\option -> option.id == id) options
         |> List.head
-
-
-findByIdWithDefault locations id =
-    findById locations id
-        |> -- TODO: crash on default? We should probably use findById always
-           Maybe.withDefault ({ id = 0, name = "", parentName = Nothing })
 
 
 setQuery model id =
     { model
-        | query = .name <| findByIdWithDefault model.locations id
-        , selectedLocation = Just <| findByIdWithDefault model.locations id
+        | query = findById model.options id |> Maybe.map .label |> Maybe.withDefault ""
+        , selection = findById model.options id
     }
 
 
@@ -179,8 +187,8 @@ close model =
     }
 
 
-view : Model -> Html Msg
-view model =
+view : OptionView a -> Model a -> Html Msg
+view optionView model =
     let
         options =
             { preventDefault = True, stopPropagation = False }
@@ -199,14 +207,14 @@ view model =
 
         menu =
             if model.showMenu then
-                [ viewMenu model ]
+                [ viewMenu optionView model ]
             else
                 []
 
         query =
-            case model.selectedLocation of
-                Just location ->
-                    location.name
+            case model.selection of
+                Just option ->
+                    option.label
 
                 Nothing ->
                     model.query
@@ -221,7 +229,7 @@ view model =
                         , onFocus OnFocus
                         , onWithOptions "keydown" options dec
                         , value query
-                        , id "location-input"
+                        , id model.inputId
                         , class "autocomplete-input"
                         , autocomplete False
                         , spellcheck False
@@ -234,7 +242,7 @@ view model =
             ]
 
 
-overlay : Model -> Html Msg
+overlay : Model a -> Html Msg
 overlay model =
     div
         [ class "autocomplete-overlay"
@@ -252,13 +260,18 @@ overlay model =
         []
 
 
-acceptableLocations : String -> List Location -> List Location
-acceptableLocations query locations =
+currentMatches : Model a -> List (Option a)
+currentMatches model =
+    matches model.query model.options
+
+
+matches : String -> List (Option a) -> List (Option a)
+matches query options =
     let
         lowerQuery =
             String.toLower query
     in
-        List.filter (String.contains lowerQuery << String.toLower << .name) locations
+        List.filter (String.contains lowerQuery << String.toLower << .label) options
 
 
 parseId : String -> Maybe Int
@@ -269,7 +282,7 @@ parseId =
 escape model =
     let
         validOptions =
-            not <| List.isEmpty (acceptableLocations model.query model.locations)
+            not <| List.isEmpty (currentMatches model)
 
         clearModel =
             if validOptions then
@@ -281,9 +294,9 @@ escape model =
                     |> removeSelection
                     |> close
     in
-        case model.selectedLocation of
-            Just location ->
-                if model.query == location.name then
+        case model.selection of
+            Just option ->
+                if model.query == option.label then
                     resetInput model
                 else
                     clearModel
@@ -292,13 +305,13 @@ escape model =
                 clearModel
 
 
-viewMenu : Model -> Html Msg
-viewMenu model =
+viewMenu : OptionView a -> Model a -> Html Msg
+viewMenu optionView model =
     div [ class "autocomplete-menu" ]
-        [ Html.map SetAutoState (Autocomplete.view viewConfig model.howManyToShow model.autoState (acceptableLocations model.query model.locations)) ]
+        [ Html.map SetAutoState (Autocomplete.view (viewConfig optionView) model.howManyToShow model.autoState (currentMatches model)) ]
 
 
-updateConfig : Autocomplete.UpdateConfig Msg Location
+updateConfig : Autocomplete.UpdateConfig Msg (Option a)
 updateConfig =
     Autocomplete.updateConfig
         { toId =
@@ -308,11 +321,11 @@ updateConfig =
                 if code == 38 || code == 40 then
                     maybeId
                         &> parseId
-                        |> Maybe.map PreviewLocation
+                        |> Maybe.map Preview
                 else if code == 13 then
                     maybeId
                         &> parseId
-                        |> Maybe.map SelectLocationKeyboard
+                        |> Maybe.map SelectKeyboard
                 else
                     Just <| Reset
         , onTooLow =
@@ -320,27 +333,24 @@ updateConfig =
         , onTooHigh =
             Just <| Wrap True
         , onMouseEnter =
-            parseId >> Maybe.map PreviewLocation
+            parseId >> Maybe.map Preview
         , onMouseLeave =
             \_ -> Nothing
         , onMouseClick =
-            parseId >> Maybe.map SelectLocationMouse
+            parseId >> Maybe.map SelectMouse
         , separateSelections = False
         }
 
 
-viewConfig : Autocomplete.ViewConfig Location
-viewConfig =
+viewConfig : OptionView a -> Autocomplete.ViewConfig (Option a)
+viewConfig optionView =
     let
-        customizedLi keySelected mouseSelected location =
+        customizedLi keySelected mouseSelected option =
             { attributes =
                 [ classList [ ( "autocomplete-item", True ), ( "key-selected", keySelected || mouseSelected ) ]
-                , id (toString location.id)
+                , id (toString option.id)
                 ]
-            , children =
-                [ Html.text location.name
-                , Html.span [ class "autocomplete-item-context" ] [ Html.text (Maybe.withDefault "" location.parentName) ]
-                ]
+            , children = optionView option.item
             }
     in
         Autocomplete.viewConfig

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -56,7 +56,7 @@ empty settings =
 init : Models.Settings -> SearchSpec -> Model
 init settings search =
     { query = Maybe.withDefault "" search.q
-    , advancedSearch = AdvancedSearch.init settings.facilityTypes settings.ownerships settings.locations search
+    , advancedSearch = AdvancedSearch.init settings.facilityTypes settings.ownerships settings.locations settings.services search
     , suggestions = Nothing
     , d = Debounce.init
     , advanced = False

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -9,7 +9,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import I18n exposing (..)
 import List
-import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership, emptySearch)
+import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership, emptySearch, querySearch)
 import Return
 import Shared exposing (icon)
 import String
@@ -38,8 +38,7 @@ type Msg
     = FacilityClicked Int
     | ServiceClicked Int
     | LocationClicked Int
-    | Search String
-    | FullSearch SearchSpec
+    | Search SearchSpec
     | Private PrivateMsg
     | UnhandledError
 
@@ -121,7 +120,7 @@ update config msg model =
                             ( { model | advanced = not model.advanced }, Cmd.none )
 
                         AdvancedSearch.Perform search ->
-                            ( model, Utils.performMessage (FullSearch search) )
+                            ( model, Utils.performMessage (Search search) )
 
                         AdvancedSearch.UnhandledError ->
                             ( model, Utils.performMessage UnhandledError )
@@ -158,7 +157,7 @@ viewInputWith : (Msg -> a) -> Model -> Html a -> Html a
 viewInputWith wmsg model trailing =
     Shared.searchBar
         model.query
-        (wmsg <| Search model.query)
+        (wmsg <| Search (querySearch model.query))
         (wmsg << Private << Input)
         (div [ class "actions" ]
             [ trailing

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -9,11 +9,13 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import I18n exposing (..)
 import List
-import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership)
+import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership, emptySearch)
 import Return
 import Shared exposing (icon)
 import String
 import Utils
+import Svg
+import Svg.Attributes
 
 
 type alias Config =
@@ -48,13 +50,13 @@ hasSuggestionsToShow model =
 
 empty : Models.Settings -> Model
 empty settings =
-    init settings ""
+    init settings emptySearch
 
 
-init : Models.Settings -> String -> Model
-init settings query =
-    { query = query
-    , advancedSearch = AdvancedSearch.init settings.facilityTypes settings.ownerships settings.locations
+init : Models.Settings -> SearchSpec -> Model
+init settings search =
+    { query = Maybe.withDefault "" search.q
+    , advancedSearch = AdvancedSearch.init settings.facilityTypes settings.ownerships settings.locations search
     , suggestions = Nothing
     , d = Debounce.init
     , advanced = False
@@ -144,7 +146,43 @@ viewInput model =
 
 viewInputWith : (Msg -> a) -> Model -> Html a -> Html a
 viewInputWith wmsg model trailing =
-    Shared.searchBar model.query (wmsg <| Search model.query) (wmsg << Private << Input) trailing
+    Shared.searchBar
+        model.query
+        (wmsg <| Search model.query)
+        (wmsg << Private << Input)
+        (div [ class "actions" ]
+            [ trailing
+            , Html.App.map wmsg (advancedSearchIcon model)
+            ]
+        )
+
+
+advancedSearchIcon : Model -> Html Msg
+advancedSearchIcon model =
+    a
+        [ href "#"
+        , Shared.onClick (Private (AdvancedSearchMsg AdvancedSearch.Toggle))
+        , classList [ ( "active", not (AdvancedSearch.isEmpty model.advancedSearch) ) ]
+        ]
+        [ filterIcon model ]
+
+
+filterIcon : Model -> Html a
+filterIcon model =
+    let
+        class =
+            (if AdvancedSearch.isEmpty model.advancedSearch then
+                ""
+             else
+                "active"
+            )
+    in
+        Svg.svg
+            [ Svg.Attributes.class class
+            , Svg.Attributes.viewBox "0 0 24 24"
+            ]
+            [ Svg.path [ Svg.Attributes.d "M22,4l-8,8v8H10V12L2,4Z" ] []
+            ]
 
 
 viewSuggestions : Model -> List (Html Msg)
@@ -154,7 +192,7 @@ viewSuggestions model =
             []
 
         Just s ->
-            [ suggestionsContent s, advancedSearchFooter ]
+            [ suggestionsContent s ]
 
 
 suggestionsContent : List Models.Suggestion -> Html Msg
@@ -211,12 +249,6 @@ suggestion s =
                 , p [ class "sub" ]
                     [ text <| Maybe.withDefault "" parentName ]
                 ]
-
-
-advancedSearchFooter =
-    div
-        [ class "footer" ]
-        [ a [ href "#", Shared.onClick (Private (AdvancedSearchMsg AdvancedSearch.Toggle)) ] [ text "Advanced Search" ] ]
 
 
 advancedSearchWindow : Model -> List (Html Msg)

--- a/app/assets/javascripts/Suggest.elm
+++ b/app/assets/javascripts/Suggest.elm
@@ -13,7 +13,7 @@ import Models exposing (MapViewport, SearchSpec, FacilityType, Ownership, emptyS
 import Return
 import Shared exposing (icon)
 import String
-import Utils
+import Utils exposing (perform)
 import Svg
 import Svg.Attributes
 
@@ -120,10 +120,12 @@ update config msg model =
                             ( { model | advanced = not model.advanced }, Cmd.none )
 
                         AdvancedSearch.Perform search ->
-                            ( model, Utils.performMessage (Search search) )
+                            Return.singleton model
+                                |> perform (Search search)
 
                         AdvancedSearch.UnhandledError ->
-                            ( model, Utils.performMessage UnhandledError )
+                            Return.singleton model
+                                |> perform UnhandledError
 
                         _ ->
                             AdvancedSearch.update model.advancedSearch msg

--- a/app/assets/javascripts/Utils.elm
+++ b/app/assets/javascripts/Utils.elm
@@ -6,6 +6,7 @@ import Date exposing (Date)
 import Time
 import Task
 import Dict exposing (Dict)
+import Return
 
 
 (&>) : Maybe a -> (a -> Maybe b) -> Maybe b
@@ -180,3 +181,8 @@ unreachable =
 performMessage : msg -> Cmd msg
 performMessage msg =
     Task.perform unreachable identity (Task.succeed msg)
+
+
+perform : msg -> ( model, Cmd msg ) -> ( model, Cmd msg )
+perform msg =
+    Return.command (performMessage msg)

--- a/app/assets/javascripts/Utils.elm
+++ b/app/assets/javascripts/Utils.elm
@@ -140,6 +140,25 @@ isJust m =
             True
 
 
+isNothing : Maybe a -> Bool
+isNothing =
+    not << isJust
+
+
+equalMaybe a b =
+    case a of
+        Nothing ->
+            isNothing b
+
+        Just xa ->
+            case b of
+                Nothing ->
+                    False
+
+                Just xb ->
+                    xa == xb
+
+
 last : List a -> Maybe a
 last l =
     List.head <| List.reverse l

--- a/app/assets/javascripts/Utils.elm
+++ b/app/assets/javascripts/Utils.elm
@@ -146,18 +146,17 @@ isNothing =
     not << isJust
 
 
+equalMaybe : Maybe a -> Maybe a -> Bool
 equalMaybe a b =
-    case a of
-        Nothing ->
-            isNothing b
+    case ( a, b ) of
+        ( Nothing, Nothing ) ->
+            True
 
-        Just xa ->
-            case b of
-                Nothing ->
-                    False
+        ( Just xa, Just xb ) ->
+            xa == xb
 
-                Just xb ->
-                    xa == xb
+        _ ->
+            False
 
 
 last : List a -> Maybe a

--- a/app/assets/stylesheets/_autocomplete.scss
+++ b/app/assets/stylesheets/_autocomplete.scss
@@ -3,6 +3,7 @@
 }
 
 .autocomplete-menu {
+  z-index: 1;
   position: absolute;
   width: 100%;
   margin-top: -15px;

--- a/app/assets/stylesheets/_modal.scss
+++ b/app/assets/stylesheets/_modal.scss
@@ -1,10 +1,11 @@
 
 .modal.open {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
   z-index: 1003;
   display: block;
   opacity: 1;
-  top: 20%;
-  position: absolute;
   margin: 0 auto;
   max-height: 80%;
   width: 400px;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -103,9 +103,11 @@ nav .nav-wrapper {
   .footer {
     padding: 18px;
     border-top: 1px solid $grey3;
-    i.material-icons {
+    .icons {
       vertical-align: top;
-      margin-right: 13px;
+      i.material-icons {
+        margin-right: 13px;
+      }
     }
     a { color: $blue; }
   }
@@ -253,15 +255,27 @@ nav .nav-wrapper {
         //Instead of the line below you could use @include box-shadow($shadow-1, $shadow-2, $shadow-3, $shadow-4, $shadow-5, $shadow-6, $shadow-7, $shadow-8, $shadow-9, $shadow-10)
         box-shadow: none !important;
       }
-      + i, + a i {
-        color: $color_mountain_mist_approx;
+      + .actions {
         position: absolute;
         right: 0;
         top: 10px;
         cursor: pointer;
-      }
-      + a:hover i {
-        color: black;
+
+        i, a i, a svg {
+          color: $color_mountain_mist_approx;
+          margin-left: 5px;
+          width: 24px;
+          height: 24px;
+        }
+        a:hover i, a.active i {
+          color: $blue;
+        }
+        a svg {
+          fill: $color_mountain_mist_approx;
+          &.active {
+            fill: $blue;
+          }
+        }
       }
     }
   }

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -31,10 +31,25 @@ class ApiController < ActionController::Base
     render json: ElasticsearchService.instance.get_facility_types
   end
 
+  def locations
+    set_cache_headers
+    render json: ElasticsearchService.instance.get_locations
+  end
+
+  def services
+    set_cache_headers
+    # TODO
+    render json: ElasticsearchService.instance.get_services.map { |s| s["name"] = s["name:en"]; s }
+  end
+
   private
 
   def search_params
     params.permit(:q, :service, :location, :type, :ownership, :lat, :lng, :size, :from)
+  end
+
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'max-age=1800'
   end
 
   def set_locale

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -38,8 +38,7 @@ class ApiController < ActionController::Base
 
   def services
     set_cache_headers
-    # TODO
-    render json: ElasticsearchService.instance.get_services.map { |s| s["name"] = s["name:en"]; s }
+    render json: ElasticsearchService.instance.get_services
   end
 
   private

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -32,14 +32,15 @@ class ApiController < ActionController::Base
   end
 
   def locations
-    set_cache_headers
-    render json: ElasticsearchService.instance.get_locations
+    locations = ElasticsearchService.instance.get_locations
+    render_if_stale(locations)
   end
 
   def services
-    set_cache_headers
-    render json: ElasticsearchService.instance.get_services
+    services = ElasticsearchService.instance.get_services
+    render_if_stale(services)
   end
+
 
   private
 
@@ -47,8 +48,20 @@ class ApiController < ActionController::Base
     params.permit(:q, :service, :location, :type, :ownership, :lat, :lng, :size, :from)
   end
 
-  def set_cache_headers
-    response.headers['Cache-Control'] = 'max-age=1800'
+  def render_if_stale(data)
+    etag = Digest::MD5.hexdigest(data.to_json)
+    client_etag = request.headers["If-None-Match"]
+
+    if client_etag.eql? etag
+      render status: 304, nothing: true
+    else
+      response.headers['ETag'] = etag
+      render status: 200, json: data
+    end
+  end
+
+  def etag(content)
+    Digest::MD5.hexdigest(locations.to_json)
   end
 
   def set_locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,10 +43,7 @@ class ApplicationController < ActionController::Base
       "locales" => Settings.locales,
       "locale" => I18n.locale,
       "facilityTypes" => ElasticsearchService.instance.get_facility_types,
-      "ownerships" => ElasticsearchService.instance.get_ownerships,
-      # TODO
-      "locations" => ElasticsearchService.instance.get_locations.map { |l| l["parentName"] = l["parent_name"]; l },
-      "services" => ElasticsearchService.instance.get_services.map { |s| s["facilityCount"] = s["facility_count"]; s["name"] = s["name:en"]; s }
+      "ownerships" => ElasticsearchService.instance.get_ownerships
     }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,7 +45,8 @@ class ApplicationController < ActionController::Base
       "facilityTypes" => ElasticsearchService.instance.get_facility_types,
       "ownerships" => ElasticsearchService.instance.get_ownerships,
       # TODO
-      "locations" => ElasticsearchService.instance.get_locations.map { |l| l["parentName"] = l["parent_name"]; l }
+      "locations" => ElasticsearchService.instance.get_locations.map { |l| l["parentName"] = l["parent_name"]; l },
+      "services" => ElasticsearchService.instance.get_services.map { |s| s["facilityCount"] = s["facility_count"]; s["name"] = s["name:en"]; s }
     }
   end
 end

--- a/app/models/elasticsearch_service.rb
+++ b/app/models/elasticsearch_service.rb
@@ -149,15 +149,18 @@ class ElasticsearchService
   end
 
   def get_locations
-    # TODO: do not fetch all locations together
     result = client.search({index: @index_name, type: 'location', body: { size: 1000 }})
     result["hits"]["hits"].map { |h| h["_source"] }
   end
 
   def get_services
-    # TODO: do not fetch all locations together
     result = client.search({index: @index_name, type: 'service', body: { size: 1000 }})
-    result["hits"]["hits"].map { |h| h["_source"] }
+
+    result["hits"]["hits"].map { |r|
+      h = r["_source"]
+      keep_i18n_field h, "name"
+      h
+    }
   end
 
   def get_facility(id)

--- a/app/models/elasticsearch_service.rb
+++ b/app/models/elasticsearch_service.rb
@@ -150,7 +150,13 @@ class ElasticsearchService
 
   def get_locations
     # TODO: do not fetch all locations together
-    result = client.search({index: @index_name, type: 'location', body: { size: 1000, sort: { id: { order: "asc" } } }})
+    result = client.search({index: @index_name, type: 'location', body: { size: 1000 }})
+    result["hits"]["hits"].map { |h| h["_source"] }
+  end
+
+  def get_services
+    # TODO: do not fetch all locations together
+    result = client.search({index: @index_name, type: 'service', body: { size: 1000 }})
     result["hits"]["hits"].map { |h| h["_source"] }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     get 'suggest', to: 'api#suggest'
     get 'facilities/:id', to: 'api#get_facility'
     get 'facility_types', to: 'api#facility_types'
+    get 'locations', to: 'api#locations'
+    get 'services', to: 'api#services'
   end
 
   post 'facilities/:id/report', to: 'application#report_facility'

--- a/elm-package.json
+++ b/elm-package.json
@@ -17,6 +17,7 @@
         "elm-lang/geolocation": "1.0.0 <= v < 2.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
         "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
+        "elm-lang/svg": "1.1.1 <= v < 2.0.0",
         "evancz/elm-http": "3.0.1 <= v < 4.0.0",
         "evancz/url-parser": "1.0.0 <= v < 2.0.0",
         "thebritican/elm-autocomplete": "4.0.2 <= v < 5.0.0"


### PR DESCRIPTION
This PR tackles #75 by adding a button in the search bar to access the advanced search window, which is now sync'ed to the search made by URL.

A filter by service was added to make advanced search a more general way of defining the same filters that can be achieved via the search bar.

To avoid unnecessarily expensive page renders, locations and services listings are now retrieved via ajax. HTTP ETags are used to prevent the clients from retrieving this information repeatedly when it hasn't been modified.