### PR TITLE
Add api/dump to download csv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'elasticsearch'
 gem 'config'
 gem 'i18n-js', '>= 3.0.0.rc14'
 gem 'http_accept_language'
-gem 'rubyzip'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-materialize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,6 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubyzip (1.2.0)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -214,7 +213,6 @@ DEPENDENCIES
   rails-assets-materialize!
   redcarpet
   rspec-rails (~> 3.5)
-  rubyzip
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/elm/Menu.elm
+++ b/app/assets/elm/Menu.elm
@@ -75,7 +75,7 @@ menuContent settings active =
                     , include <| hr [] []
                     , include <|
                         li []
-                            [ a [ href <| "/data" ]
+                            [ a [ href <| "/api/dump" ]
                                 [ icon "file_download"
                                 , text <| t I18n.FullDownload
                                 ]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,10 +32,6 @@ class ApplicationController < ActionController::Base
     head :ok
   end
 
-  def download_dataset
-    send_file(Rails.root + "data/full_dataset.zip", type: "application/zip")
-  end
-
   protected
 
   def set_js_flags

--- a/bin/import-dataset
+++ b/bin/import-dataset
@@ -13,7 +13,6 @@ input_path = ARGV[0]
 
 ENV["ELASTICSEARCH_LOG"] ||= "0"
 
-File.delete("data/full_dataset.zip") if File.exists?("data/full_dataset.zip")
 ElasticsearchService.instance.drop_index rescue nil
 ElasticsearchService.instance.setup_index
 ElasticsearchService.instance.setup_mappings
@@ -22,7 +21,6 @@ ElasticsearchService.instance.setup_mappings
 def import(path)
   dataset = Indexing.read_csv_dataset(path)
   Indexing.index_dataset(dataset)
-  Dump.dump_zip("data/full_dataset.zip")
 end
 
 if File.file? input_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   scope :api do
     get 'search', to: 'api#search'
+    get 'dump', to: 'api#dump'
     get 'suggest', to: 'api#suggest'
     get 'facilities/:id', to: 'api#get_facility'
     get 'facility_types', to: 'api#facility_types'
@@ -22,7 +23,6 @@ Rails.application.routes.draw do
   end
 
   post 'facilities/:id/report', to: 'application#report_facility'
-  get 'data', to: 'application#download_dataset'
   get 'map', to: 'application#map'
 
   get '*unmatched_route', :to => 'application#map'

--- a/spec/dump_spec.rb
+++ b/spec/dump_spec.rb
@@ -141,12 +141,12 @@ RSpec.describe Dump do
   end
 
   def dump_and_read(dataset, locales = [:en, :es], page_size = 100)
-    output_file = Tempfile.new("out")
+    output_io = StringIO.new
 
     index_dataset(dataset, locales)
-    dump_dataset(output_file.path, page_size, locales)
+    dump_dataset(output_io, page_size, locales)
 
-    CSV.read(output_file.path, headers: true, converters: [:blank_to_nil])
+    CSV.parse(output_io.string, headers: true, converters: [:blank_to_nil])
        .map(&:to_h)
   end
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -24,7 +24,7 @@ module Helpers
     elasticsearch_service.refresh_index
   end
 
-  def dump_dataset(output_path, page_size, locales = Settings.locales.keys)
-    Dump.new(output_path, elasticsearch_service, page_size, locales).run
+  def dump_dataset(output_io, page_size, locales = Settings.locales.keys)
+    Dump.new({}, output_io, elasticsearch_service, page_size, locales).run
   end
 end


### PR DESCRIPTION
* replace /data for /api/dump
  * full_dataset.zip is no longer generated
  * rubyzip gem is no longer needed
* /api/dump supports same search parameters as query
* dump & search in elasticsearch_services refactored to share filtering code.
* api_controller#dump stream csv using ActionController::Live
* Dump works with IO (StringIO for spec, response.stream in controller)

cc: @juanedi 