### PR TITLE
Move development to PostgreSQL 12.5

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -12,7 +12,7 @@ services:
       - '3080:3080'
 
   db:
-    image: postgres:12.5
+    image: postgres:12-alpine
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -12,7 +12,7 @@ services:
       - '3080:3080'
 
   db:
-    image: postgres:9.5
+    image: postgres:12.5
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD:
@@ -44,4 +44,3 @@ services:
 volumes:
   db:
   elastic:
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - '3080:3080'
 
   db:
-    image: postgres:9.5
+    image: postgres:12.5
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
@@ -43,4 +43,3 @@ volumes:
   elastic:
   bundle:
   elm-stuff:
-


### PR DESCRIPTION
PostgreSQL 9.5 is reaching End of Life, so we'll move to 12.5 - the most recent stable version.

See https://www.postgresql.org/support/versioning/#Releases