### PR TITLE
Fix: initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 # Elm
 /elm-stuff
+/vendor/assets/elm
 
 /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,37 @@
-FROM ruby:2.3.8
+FROM ruby:2.3
 
-RUN \
-  apt-get update && \
-  # node
-  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-  apt-get install -y nodejs && \
-  # elm
-  npm install -g elm@0.17.1 --unsafe-perm=true --allow-root && \
-  # clean
-  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
-# Install dependencies
-RUN mkdir /app
+# Debian stretch has been archived
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
+# Install Node.js
+RUN apt-get -qq update && \
+    apt-get -qq -y install apt-transport-https ca-certificates curl gnupg && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get -qq update && \
+    apt-get -qq install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Elm
+RUN cd /usr/local/bin && \
+    curl -L "https://github.com/lydell/elm-old-binaries/releases/download/main/0.17.1-linux-x64.tar.gz" | tar xz --strip-components=1
+
 WORKDIR /app
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
+
+COPY Gemfile Gemfile.lock .
 RUN bundle install --jobs 3 --deployment --without development test
-ADD elm-package.json /app/elm-package.json
+
+COPY elm-package.json .
+RUN git clone -b 4.0.2 https://github.com/thebritican/elm-autocomplete vendor/assets/elm/elm-autocomplete
 RUN elm package install --yes
 
-# Install the application
-ADD . /app
+COPY . /app
 
-# Precompile assets
-RUN /bin/bash ./bin/precompile-assets.sh
+RUN ./bin/precompile-assets.sh
 
 ENV RAILS_ENV production
 ENV RAILS_SERVE_STATIC_FILES true

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,11 +1,23 @@
-FROM ruby:2.3.8
+FROM ruby:2.3
 
-RUN \
-  apt-get update && \
-  # node
-  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-  apt-get install -y nodejs && \
-  # elm
-  npm install -g elm@0.17.1 --unsafe-perm=true --allow-root && \
-  # clean
-  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
+# Debian stretch has been archived
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+
+# Install Node 8.x
+RUN apt-get -qq update && \
+    apt-get -qq -y install apt-transport-https ca-certificates curl gnupg && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get -qq update && \
+    apt-get -qq install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Elm 0.17.x
+RUN cd /usr/local/bin && \
+    curl -L "https://github.com/lydell/elm-old-binaries/releases/download/main/0.17.1-linux-x64.tar.gz" | tar xz --strip-components=1
+
+WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,46 +1,48 @@
 source 'https://rubygems.org'
 
-
+# frameworks
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'devise'
+
+# services
 gem 'pg'
+gem 'elasticsearch'
 gem 'puma', '~> 3.0'
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '~> 4.2'
-gem 'coffee-rails', '~> 4.2'
+
+# libraries
+# gem 'bcrypt', '~> 3.1.7'
+gem 'config'
+gem 'google-api-client'
+gem 'http_accept_language'
+gem 'jbuilder', '~> 2.5'
 gem 'redcarpet'
-# See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-gem 'elasticsearch'
-gem 'config'
+# assets
+gem 'coffee-rails', '~> 4.2'
 gem 'i18n-js', '>= 3.0.0.rc14'
-gem 'http_accept_language'
-gem 'google-api-client'
+gem 'jquery-rails'
+gem 'sass-rails', '~> 5.0'
+gem 'uglifier', '~> 4.2'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-materialize'
   gem 'rails-assets-leaflet'
   gem 'rails-assets-leaflet.markercluster'
-end
-
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
-  gem 'rspec-rails', '~> 3.5'
+  gem 'rails-assets-jquery'
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'web-console'
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  # gem 'web-console'
+end
+
+group :development, :test do
+  gem 'byebug', platform: :mri
+end
+
+group :test do
+  gem 'rspec-rails', '~> 3.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,6 @@ GEM
       activesupport (>= 3.0)
       deep_merge (~> 1.1.1)
     crass (1.0.4)
-    debug_inspector (0.0.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
     deep_merge (1.1.1)
@@ -237,11 +236,6 @@ GEM
       execjs (>= 0.3.0, < 3)
     warden (1.2.8)
       rack (>= 2.0.6)
-    web-console (3.3.1)
-      actionview (>= 5.0)
-      activemodel (>= 5.0)
-      debug_inspector
-      railties (>= 5.0)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -264,6 +258,7 @@ DEPENDENCIES
   pg
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-assets-jquery!
   rails-assets-leaflet!
   rails-assets-leaflet.markercluster!
   rails-assets-materialize!
@@ -273,7 +268,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (~> 4.2)
-  web-console
 
 BUNDLED WITH
    1.17.3

--- a/bin/setup
+++ b/bin/setup
@@ -14,9 +14,14 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
+  puts "== Installing ruby dependencies =="
+  # system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+
+  puts "\n== Installing elm dependencies =="
+  unless Dir.exists?('vendor/assets/elm/elm-autocomplete')
+    system! 'git clone -b 4.0.2 https://github.com/thebritican/elm-autocomplete vendor/assets/elm/elm-autocomplete'
+  end
   system! 'elm package install --yes'
 
   # puts "\n== Copying sample files =="

--- a/bin/update
+++ b/bin/update
@@ -14,9 +14,14 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
+  puts "== Installing ruby dependencies =="
+  # system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+
+  puts "\n== Installing elm dependencies =="
+  unless Dir.exists?('vendor/assets/elm/elm-autocomplete')
+    system! 'git clone -b 4.0.2 https://github.com/thebritican/elm-autocomplete vendor/assets/elm/elm-autocomplete'
+  end
   system! 'elm package install --yes'
 
   puts "\n== Updating database =="

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.web_console.whitelisted_ips = '0.0.0.0/0'
+  # config.web_console.whitelisted_ips = '0.0.0.0/0'
 
   config.middleware.use I18n::JS::Middleware
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: elasticsearch:2.4
+    image: elasticsearch:2.4-alpine
     volumes:
       - elastic:/usr/share/elasticsearch/data
 
@@ -9,10 +9,10 @@ services:
     image: 'djfarrelly/maildev:latest'
     command: 'bin/maildev --web 3080 --smtp 1025 --incoming-user smtp --incoming-pass smtp'
     ports:
-      - '3080:3080'
+      - '3081:3080'
 
   db:
-    image: postgres:9.5
+    image: postgres:9.5-alpine
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root

--- a/elm-package.json
+++ b/elm-package.json
@@ -4,7 +4,8 @@
     "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
-        "./app/assets/elm"
+        "./app/assets/elm",
+        "./vendor/assets/elm/elm-autocomplete/src"
     ],
     "exposed-modules": [],
     "native-modules": true,
@@ -16,11 +17,11 @@
         "elm-lang/dom": "1.1.0 <= v < 2.0.0",
         "elm-lang/geolocation": "1.0.0 <= v < 2.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
+        "elm-lang/keyboard": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
         "elm-lang/svg": "1.1.1 <= v < 2.0.0",
         "evancz/elm-http": "3.0.1 <= v < 4.0.0",
-        "evancz/url-parser": "1.0.0 <= v < 2.0.0",
-        "thebritican/elm-autocomplete": "4.0.2 <= v < 5.0.0"
+        "evancz/url-parser": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.1 <= v < 0.18.0"
 }


### PR DESCRIPTION
- debian stretch has been archived;
- nodejs install script has been deprecated;
- elm 0.17 can't be installed from npm anymore;
- elm-autocomplete pkg can't be installed anymore;
- reorganize/simplify gemfile.

Also switches to the smaller alpine variants of ES and PG images.